### PR TITLE
StdLib: Fix various typos

### DIFF
--- a/StdLib/BsdSocketLib/bind.c
+++ b/StdLib/BsdSocketLib/bind.c
@@ -59,7 +59,7 @@ bind (
                                         &errno );
   }
 
-  //  Return the operation stauts
+  //  Return the operation status
   BindStatus = ( 0 == errno ) ? 0 : -1;
   return BindStatus;
 }

--- a/StdLib/BsdSocketLib/getsockopt.c
+++ b/StdLib/BsdSocketLib/getsockopt.c
@@ -52,7 +52,7 @@ getsockopt (
                                              option_len,
                                              &errno );
   }
-  //  Return the operation stauts
+  //  Return the operation status
   OptionStatus = ( 0 == errno ) ? 0 : -1;
   return OptionStatus;
 }

--- a/StdLib/BsdSocketLib/listen.c
+++ b/StdLib/BsdSocketLib/listen.c
@@ -50,7 +50,7 @@ listen (
                                           backlog,
                                           &errno );
   }
-  //  Return the operation stauts
+  //  Return the operation status
   ListenStatus = ( 0 == errno ) ? 0 : -1;
   return ListenStatus;
 }

--- a/StdLib/BsdSocketLib/ns_addr.c
+++ b/StdLib/BsdSocketLib/ns_addr.c
@@ -71,10 +71,10 @@ ns_addr(
   buf[sizeof(buf) - 1] = '\0';
 
   /*
-   * First, figure out what he intends as a field separtor.
-   * Despite the way this routine is written, the prefered
+   * First, figure out what he intends as a field separator.
+   * Despite the way this routine is written, the preferred
    * form  2-272.AA001234H.01777, i.e. XDE standard.
-   * Great efforts are made to insure backward compatability.
+   * Great efforts are made to insure backward compatibility.
    */
   if ((hostname = strchr(buf, '#')) != NULL)
     separator = '#';
@@ -145,7 +145,7 @@ Field(
   }
   /*
    * This is REALLY stretching it but there was a
-   * comma notation separting shorts -- definitely non standard
+   * comma notation separating shorts -- definitely non standard
    */
   if (1 < (i = sscanf(buf,"%x,%x,%x",
       &hb[0], &hb[1], &hb[2]))) {

--- a/StdLib/BsdSocketLib/res_comp.c
+++ b/StdLib/BsdSocketLib/res_comp.c
@@ -108,7 +108,7 @@ static char rcsid[] = "$Id: res_comp.c,v 1.1.1.1 2003/11/19 01:51:35 kyu3 Exp $"
 
 /*
  * Expand compressed domain name 'comp_dn' to full domain name.
- * 'msg' is a pointer to the begining of the message,
+ * 'msg' is a pointer to the beginning of the message,
  * 'eomorig' points to the first location after the message,
  * 'exp_dn' is a pointer to a buffer of size 'length' for the result.
  * Return size of compressed name or -1 if there was an error.

--- a/StdLib/BsdSocketLib/res_config.h
+++ b/StdLib/BsdSocketLib/res_config.h
@@ -1,8 +1,8 @@
 #define DEBUG   1   /* enable debugging code (needed for dig) */
 #define RESOLVSORT  /* allow sorting of addresses in gethostbyname */
-#define RFC1535     /* comply with RFC1535 (STRONGLY reccomended by vixie)*/
+#define RFC1535     /* comply with RFC1535 (STRONGLY recommended by vixie)*/
 #undef  USELOOPBACK /* res_init() bind to localhost */
-#undef  SUNSECURITY /* verify gethostbyaddr() calls - WE DONT NEED IT  */
+#undef  SUNSECURITY /* verify gethostbyaddr() calls - WE DON'T NEED IT  */
 #define MULTI_PTRS_ARE_ALIASES 1 /* fold multiple PTR records into aliases */
 #define CHECK_SRVR_ADDR 1 /* confirm that the server requested sent the reply */
 #define BIND_UPDATE 1   /* update support */

--- a/StdLib/BsdSocketLib/setsockopt.c
+++ b/StdLib/BsdSocketLib/setsockopt.c
@@ -51,7 +51,7 @@ setsockopt (
                                           option_len,
                                           &errno );
   }
-  //  Return the operation stauts
+  //  Return the operation status
   OptionStatus = ( 0 == errno ) ? 0 : -1;
   return OptionStatus;
 }

--- a/StdLib/BsdSocketLib/socket.c
+++ b/StdLib/BsdSocketLib/socket.c
@@ -190,7 +190,7 @@ BslSocketProtocolToFd (
                           </li>
                           <li>
                             SOCK_STREAM - Connect to TCP, provides a byte stream
-                            that is manipluated by read, recv, send and write.
+                            that is manipulated by read, recv, send and write.
                           </li>
                           <li>
                             SOCK_RAW - Connect to IP, provides a datagram service that

--- a/StdLib/Efi/StdLib/etc/services
+++ b/StdLib/Efi/StdLib/etc/services
@@ -239,7 +239,7 @@ pop3s		995/udp
 #> providing services to unknown callers, a service contact port is
 #> defined.  This list specifies the port used by the server process as its
 #> contact port.  While the IANA can not control uses of these ports it
-#> does register or list uses of these ports as a convienence to the
+#> does register or list uses of these ports as a convenience to the
 #> community.
 #
 socks		1080/tcp			# socks proxy server
@@ -400,7 +400,7 @@ afs3-vlserver	7003/tcp			# volume location database
 afs3-vlserver	7003/udp
 afs3-kaserver	7004/tcp			# AFS/Kerberos authentication
 afs3-kaserver	7004/udp
-afs3-volser	7005/tcp			# volume managment server
+afs3-volser	7005/tcp			# volume management server
 afs3-volser	7005/udp
 afs3-errors	7006/tcp			# error interpretation service
 afs3-errors	7006/udp

--- a/StdLib/EfiSocketLib/Ip4.c
+++ b/StdLib/EfiSocketLib/Ip4.c
@@ -375,7 +375,7 @@ EslIp4PortAllocate (
 
   @param [in] pbConsumePacket Address of a BOOLEAN indicating if the packet is to be consumed
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 
@@ -489,7 +489,7 @@ EslIp4Receive (
   This routine returns the address of the remote connection point
   associated with the SOCK_RAW socket.
 
-  This routine is called by ::EslSocketGetPeerAddress to detemine
+  This routine is called by ::EslSocketGetPeerAddress to determine
   the IPv4 address associated with the network adapter.
 
   @param [in] pPort       Address of an ::ESL_PORT structure.
@@ -877,7 +877,7 @@ EslIp4RxComplete (
 
   @param [in] Flags           Message control flags
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 

--- a/StdLib/EfiSocketLib/Socket.c
+++ b/StdLib/EfiSocketLib/Socket.c
@@ -177,7 +177,7 @@
 
   The receive engine is the state machine which reads data from the network and
   fills the queue with received packets.  The receive engine uses two data structures
-  to manage the network receive opeations and the buffers.
+  to manage the network receive operations and the buffers.
 
   At a high level, the ::ESL_IO_MGMT structures are managing the tokens and
   events for the interface to the UEFI network stack.  The ::ESL_PACKET
@@ -263,7 +263,7 @@
   ::EslSocketRxStart connects an ::ESL_PACKET structure to the ::ESL_IO_MGMT structure
   and then calls the network layer to start the receive operation.  Upon
   receive completion, ::EslSocketRxComplete breaks the connection between these
-  structrues and places the ESL_IO_MGMT structure onto the ESL_PORT::pRxFree list to
+  structures and places the ESL_IO_MGMT structure onto the ESL_PORT::pRxFree list to
   make token and event available for another receive operation.  EslSocketRxComplete
   then queues the ESL_PACKET structure (data packet) to either the
   ESL_SOCKET::pRxOobPacketListTail or ESL_SOCKET::pRxPacketListTail depending on
@@ -1802,7 +1802,7 @@ EslSocketConnect (
 
   @param[in]  FragmentCount   Number of fragments in the table
   @param[in]  pFragmentTable  Address of an EFI_IP4_FRAGMENT_DATA structure
-  @param[in]  BufferLength    Length of the the buffer
+  @param[in]  BufferLength    Length of the buffer
   @param[in]  pBuffer         Address of a buffer to receive the data.
   @param[in]  pDataLength     Number of received data bytes in the buffer.
 
@@ -4326,7 +4326,7 @@ EslSocketPortCloseTxDone (
 
   @param[in]      pSocketProtocol Address of an ::EFI_SOCKET_PROTOCOL structure.
   @param[in]      Flags           Message control flags
-  @param[in]      BufferLength    Length of the the buffer
+  @param[in]      BufferLength    Length of the buffer
   @param[in]      pBuffer         Address of a buffer to receive the data.
   @param[in]      pDataLength     Number of received data bytes in the buffer.
   @param[out]     pAddress        Network address to receive the remote system address
@@ -5299,7 +5299,7 @@ EslSocketShutdown (
 
   @param[in]  pSocketProtocol Address of an ::EFI_SOCKET_PROTOCOL structure.
   @param[in]  Flags           Message control flags
-  @param[in]  BufferLength    Length of the the buffer
+  @param[in]  BufferLength    Length of the buffer
   @param[in]  pBuffer         Address of a buffer containing the data to send
   @param[in]  pDataLength     Address to receive the number of data bytes sent
   @param[in]  pAddress        Network address of the remote system address

--- a/StdLib/EfiSocketLib/Socket.h
+++ b/StdLib/EfiSocketLib/Socket.h
@@ -349,7 +349,7 @@ typedef struct {
   Configure the network layer.
 
   @param [in] pProtocol   Protocol structure address
-  @param [in] pConfigData Address of the confiuration data
+  @param [in] pConfigData Address of the configuration data
 
   @return   Returns EFI_SUCCESS if the operation is successfully
             started.
@@ -513,7 +513,7 @@ EFI_STATUS
   Attempt to connect to a remote TCP port
 
   This routine starts the connection processing for a SOCK_STREAM
-  or SOCK_SEQPAKCET socket using the TCP network layer.
+  or SOCK_SEQPACKET socket using the TCP network layer.
 
   This routine is called by ::EslSocketConnect to initiate the TCP
   network specific connect operations.
@@ -776,7 +776,7 @@ EFI_STATUS
   
   @param [in] pbConsumePacket Address of a BOOLEAN indicating if the packet is to be consumed
   
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
   
   @param [in] pBuffer         Address of a buffer to receive the data.
   
@@ -868,7 +868,7 @@ VOID
 
   @param [in] Flags           Message control flags
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 
@@ -996,7 +996,7 @@ typedef struct _ESL_SOCKET {
   //
   ESL_SOCKET * pNext;           ///<  Next socket in the list of sockets
   int errno;                    ///<  Error information for this socket
-  EFI_STATUS Status;            ///<  Asyncronous error information for this socket
+  EFI_STATUS Status;            ///<  Asynchronous error information for this socket
   SOCKET_STATE State;           ///<  Socket state
   UINT32 DebugFlags;            ///<  Debug flags
 
@@ -1183,7 +1183,7 @@ EslSocketBindTest (
 
   @param [in] pFragmentTable  Address of an EFI_IP4_FRAGMENT_DATA structure
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 

--- a/StdLib/EfiSocketLib/Tcp4.c
+++ b/StdLib/EfiSocketLib/Tcp4.c
@@ -27,7 +27,7 @@
   Attempt to connect to a remote TCP port
 
   This routine starts the connection processing for a SOCK_STREAM
-  or SOCK_SEQPAKCET socket using the TCPv4 network layer.  It
+  or SOCK_SEQPACKET socket using the TCPv4 network layer.  It
   configures the local TCPv4 connection point and then attempts to
   connect to a remote system.  Upon completion, the
   ::EslTcp4ConnectComplete routine gets called with the connection
@@ -449,7 +449,7 @@ EslTcp4ConnectPoll (
   Attempt to connect to a remote TCP port
 
   This routine starts the connection processing for a SOCK_STREAM
-  or SOCK_SEQPAKCET socket using the TCPv4 network layer.  It
+  or SOCK_SEQPACKET socket using the TCPv4 network layer.  It
   configures the local TCPv4 connection point and then attempts to
   connect to a remote system.  Upon completion, the
   ::EslTcp4ConnectComplete routine gets called with the connection
@@ -1499,7 +1499,7 @@ EslTcp4PortCloseOp (
 
   @param [in] pbConsumePacket Address of a BOOLEAN indicating if the packet is to be consumed
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 
@@ -1625,7 +1625,7 @@ EslTcp4Receive (
   This routine returns the address of the remote connection point
   associated with the SOCK_STREAM or SOCK_SEQPACKET socket.
 
-  This routine is called by ::EslSocketGetPeerAddress to detemine
+  This routine is called by ::EslSocketGetPeerAddress to determine
   the TCPv4 address and por number associated with the network adapter.
 
   @param [in] pPort       Address of an ::ESL_PORT structure.
@@ -1883,7 +1883,7 @@ EslTcp4RxStart (
 
   @param [in] Flags           Message control flags
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 
@@ -1968,7 +1968,7 @@ EslTcp4TxBuffer (
       if ( pSocket->MaxTxBuf > *pTxBytes ) {
         if ( pPort->bTxFlowControl ) {
           DEBUG (( DEBUG_TX,
-                    "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\r\n0x%08x: pPort, TX flow control released, Max bytes: %d > %d bufferred bytes\r\n",
+                    "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\r\n0x%08x: pPort, TX flow control released, Max bytes: %d > %d buffered bytes\r\n",
                     pPort,
                     pSocket->MaxTxBuf,
                     *pTxBytes ));
@@ -2084,7 +2084,7 @@ EslTcp4TxBuffer (
       else {
         if ( !pPort->bTxFlowControl ) {
           DEBUG (( DEBUG_TX,
-                    "0x%08x: pPort, TX flow control applied, Max bytes %d <= %d bufferred bytes\r\nTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\r\n",
+                    "0x%08x: pPort, TX flow control applied, Max bytes %d <= %d buffered bytes\r\nTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\r\n",
                     pPort,
                     pSocket->MaxTxBuf,
                     *pTxBytes ));

--- a/StdLib/EfiSocketLib/Tcp6.c
+++ b/StdLib/EfiSocketLib/Tcp6.c
@@ -27,7 +27,7 @@
   Attempt to connect to a remote TCP port
 
   This routine starts the connection processing for a SOCK_STREAM
-  or SOCK_SEQPAKCET socket using the TCPv6 network layer.  It
+  or SOCK_SEQPACKET socket using the TCPv6 network layer.  It
   configures the local TCPv6 connection point and then attempts to
   connect to a remote system.  Upon completion, the
   ::EslTcp6ConnectComplete routine gets called with the connection
@@ -467,7 +467,7 @@ EslTcp6ConnectPoll (
   Attempt to connect to a remote TCP port
 
   This routine starts the connection processing for a SOCK_STREAM
-  or SOCK_SEQPAKCET socket using the TCPv6 network layer.  It
+  or SOCK_SEQPACKET socket using the TCPv6 network layer.  It
   configures the local TCPv6 connection point and then attempts to
   connect to a remote system.  Upon completion, the
   ::EslTcp6ConnectComplete routine gets called with the connection
@@ -1551,7 +1551,7 @@ EslTcp6PortCloseOp (
 
   @param [in] pbConsumePacket Address of a BOOLEAN indicating if the packet is to be consumed
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 
@@ -1689,7 +1689,7 @@ EslTcp6Receive (
   This routine returns the address of the remote connection point
   associated with the SOCK_STREAM or SOCK_SEQPACKET socket.
 
-  This routine is called by ::EslSocketGetPeerAddress to detemine
+  This routine is called by ::EslSocketGetPeerAddress to determine
   the TCPv6 address and por number associated with the network adapter.
 
   @param [in] pPort       Address of an ::ESL_PORT structure.
@@ -1952,7 +1952,7 @@ EslTcp6RxStart (
 
   @param [in] Flags           Message control flags
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 
@@ -2037,7 +2037,7 @@ EslTcp6TxBuffer (
       if ( pSocket->MaxTxBuf > *pTxBytes ) {
         if ( pPort->bTxFlowControl ) {
           DEBUG (( DEBUG_TX,
-                    "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\r\n0x%08x: pPort, TX flow control released, Max bytes: %d > %d bufferred bytes\r\n",
+                    "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\r\n0x%08x: pPort, TX flow control released, Max bytes: %d > %d buffered bytes\r\n",
                     pPort,
                     pSocket->MaxTxBuf,
                     *pTxBytes ));
@@ -2153,7 +2153,7 @@ EslTcp6TxBuffer (
       else {
         if ( !pPort->bTxFlowControl ) {
           DEBUG (( DEBUG_TX,
-                    "0x%08x: pPort, TX flow control applied, Max bytes %d <= %d bufferred bytes\r\nTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\r\n",
+                    "0x%08x: pPort, TX flow control applied, Max bytes %d <= %d buffered bytes\r\nTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\r\n",
                     pPort,
                     pSocket->MaxTxBuf,
                     *pTxBytes ));

--- a/StdLib/EfiSocketLib/Udp4.c
+++ b/StdLib/EfiSocketLib/Udp4.c
@@ -288,7 +288,7 @@ EslUdp4PortAllocate (
   
   @param [in] pbConsumePacket Address of a BOOLEAN indicating if the packet is to be consumed
   
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
   
   @param [in] pBuffer         Address of a buffer to receive the data.
   
@@ -383,7 +383,7 @@ EslUdp4Receive (
   This routine returns the address of the remote connection point
   associated with the SOCK_DGRAM socket.
 
-  This routine is called by ::EslSocketGetPeerAddress to detemine
+  This routine is called by ::EslSocketGetPeerAddress to determine
   the UDPv4 address and port number associated with the network adapter.
 
   @param [in] pPort       Address of an ::ESL_PORT structure.
@@ -740,7 +740,7 @@ EslUdp4RxComplete (
 
   @param [in] Flags           Message control flags
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 

--- a/StdLib/EfiSocketLib/Udp6.c
+++ b/StdLib/EfiSocketLib/Udp6.c
@@ -272,7 +272,7 @@ EslUdp6PortAllocate (
   
   @param [in] pbConsumePacket Address of a BOOLEAN indicating if the packet is to be consumed
   
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
   
   @param [in] pBuffer         Address of a buffer to receive the data.
   
@@ -379,7 +379,7 @@ EslUdp6Receive (
   This routine returns the address of the remote connection point
   associated with the SOCK_DGRAM socket.
 
-  This routine is called by ::EslSocketGetPeerAddress to detemine
+  This routine is called by ::EslSocketGetPeerAddress to determine
   the UDPv4 address and port number associated with the network adapter.
 
   @param [in] pPort       Address of an ::ESL_PORT structure.
@@ -785,7 +785,7 @@ EslUdp6RxComplete (
 
   @param [in] Flags           Message control flags
 
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
 
   @param [in] pBuffer         Address of a buffer to receive the data.
 

--- a/StdLib/EfiSocketLib/UseEfiSocketLib.c
+++ b/StdLib/EfiSocketLib/UseEfiSocketLib.c
@@ -353,7 +353,7 @@ EslServiceNetworkDisconnect (
 
 
 /**
-  Socket layer's service binding protocol delcaration.
+  Socket layer's service binding protocol declaration.
 **/
 CONST EFI_SERVICE_BINDING_PROTOCOL mEfiServiceBinding __attribute__((weak)) = {
   NULL,

--- a/StdLib/Include/Efi/EfiSocketLib.h
+++ b/StdLib/Include/Efi/EfiSocketLib.h
@@ -129,7 +129,7 @@
 // Data Types
 //------------------------------------------------------------------------------
 
-typedef struct _ESL_SERVICE ESL_SERVICE;  ///<  Forward delcaration
+typedef struct _ESL_SERVICE ESL_SERVICE;  ///<  Forward declaration
 
 /**
   Protocol binding and installation control structure
@@ -652,7 +652,7 @@ EslSocketPoll (
   
   @param [in] Flags           Message control flags
   
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
   
   @param [in] pBuffer         Address of a buffer to receive the data.
   
@@ -720,7 +720,7 @@ EslSocketShutdown (
   
   @param [in] Flags           Message control flags
   
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
   
   @param [in] pBuffer         Address of a buffer containing the data to send
   

--- a/StdLib/Include/Protocol/EfiSocket.h
+++ b/StdLib/Include/Protocol/EfiSocket.h
@@ -429,7 +429,7 @@ EFI_STATUS
   
   @param [in] Flags           Message control flags
   
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
   
   @param [in] pBuffer         Address of a buffer to receive the data.
   
@@ -532,7 +532,7 @@ EFI_STATUS
   
   @param [in] Flags           Message control flags
   
-  @param [in] BufferLength    Length of the the buffer
+  @param [in] BufferLength    Length of the buffer
   
   @param [in] pBuffer         Address of a buffer containing the data to send
   

--- a/StdLib/Include/X64/machine/asm.h
+++ b/StdLib/Include/X64/machine/asm.h
@@ -122,7 +122,7 @@
 #endif /* __STDC__ */
 
 /*
- * Assembley equivalent of spllower().  Label contains the label to jump to
+ * Assembly equivalent of spllower().  Label contains the label to jump to
  * if we need to fire off pending interrupts (e.g. _C_LABEL(Xspllower)).
  *
  * On entry %rcx = new SPL.

--- a/StdLib/Include/arpa/telnet.h
+++ b/StdLib/Include/arpa/telnet.h
@@ -213,7 +213,7 @@ char *telopts[NTELOPTS+1] = {
 #define	NSLC		30
 
 /*
- * For backwards compatability, we define SLC_NAMES to be the
+ * For backwards compatibility, we define SLC_NAMES to be the
  * list of names if SLC_NAMES is not defined.
  */
 #define	SLC_NAMELIST	"0", "SYNCH", "BRK", "IP", "AO", "AYT", "EOR",	\

--- a/StdLib/Include/errno.h
+++ b/StdLib/Include/errno.h
@@ -18,7 +18,7 @@
   of errno is not documented in the description of the function in
   the governing standard: ISO/IEC 9899:1990 with Amendment 1 or ISO/IEC 9899:199409.
 
-  EFIerrno, like errno, should only be checked if it is known that the preceeding function call
+  EFIerrno, like errno, should only be checked if it is known that the preceding function call
   called a UEFI function.  Functions in which UEFI functions are called dependent upon context
   or parameter values should guarantee that EFIerrno is set to zero by default, or to the status
   value returned by any UEFI functions which are called.

--- a/StdLib/Include/locale.h
+++ b/StdLib/Include/locale.h
@@ -93,7 +93,7 @@ struct lconv {
                                                   the international currency symbol from the monetary quantity. */
   char  *currency_symbol;         /**< ""         The local currency symbol for the current locale. */
   char  *mon_decimal_point;       /**< ""         The decimal point used for monetary values. */
-  char  *mon_thousands_sep;       /**< ""         The separator for digit groups preceeding the decimal-point. */
+  char  *mon_thousands_sep;       /**< ""         The separator for digit groups preceding the decimal-point. */
   char  *mon_grouping;            /**< ""         A string, like grouping, for monetary values. */
   char  *positive_sign;           /**< ""         A string to indicate a non-negative monetary value. */
   char  *negative_sign;           /**< ""         A string to indicate a negative monetary value. */

--- a/StdLib/Include/net/if.h
+++ b/StdLib/Include/net/if.h
@@ -39,7 +39,7 @@
 
 /*
  * <net/if.h> does not depend on <sys/time.h> on most other systems.  This
- * helps userland compatability.  (struct timeval ifi_lastchange)
+ * helps userland compatibility.  (struct timeval ifi_lastchange)
  */
 #ifndef KERNEL
 #include <sys/time.h>
@@ -109,7 +109,7 @@ struct if_data {
  */
 struct if_msghdr {
 	u_short	ifm_msglen;	/* to skip over non-understood messages */
-	u_char	ifm_version;	/* future binary compatability */
+	u_char	ifm_version;	/* future binary compatibility */
 	u_char	ifm_type;	/* message type */
 	int	ifm_addrs;	/* like rtm_addrs */
 	int	ifm_flags;	/* value of if_flags */
@@ -123,7 +123,7 @@ struct if_msghdr {
  */
 struct ifa_msghdr {
 	u_short	ifam_msglen;	/* to skip over non-understood messages */
-	u_char	ifam_version;	/* future binary compatability */
+	u_char	ifam_version;	/* future binary compatibility */
 	u_char	ifam_type;	/* message type */
 	int	ifam_addrs;	/* like rtm_addrs */
 	int	ifam_flags;	/* value of ifa_flags */
@@ -137,7 +137,7 @@ struct ifa_msghdr {
  */
 struct ifma_msghdr {
 	u_short	ifmam_msglen;	/* to skip over non-understood messages */
-	u_char	ifmam_version;	/* future binary compatability */
+	u_char	ifmam_version;	/* future binary compatibility */
 	u_char	ifmam_type;	/* message type */
 	int	ifmam_addrs;	/* like rtm_addrs */
 	int	ifmam_flags;	/* value of ifa_flags */

--- a/StdLib/Include/netdb.h
+++ b/StdLib/Include/netdb.h
@@ -127,7 +127,7 @@ struct  hostent {
   int     h_length;     /**< length of address */
   char  **h_addr_list;  /**< list of addresses from name server */
 };
-#define h_addr  h_addr_list[0]  /**< address, for backward compatiblity */
+#define h_addr  h_addr_list[0]  /**< address, for backward compatibility */
 
 /** Assumption here is that a network number
  *  fits in an unsigned long -- probably a poor one.

--- a/StdLib/Include/netns/ns.h
+++ b/StdLib/Include/netns/ns.h
@@ -63,7 +63,7 @@
 #define NSPORT_RE	3		/* Router Error */
 
 /*
- * Ports < NSPORT_RESERVED are reserved for priveleged
+ * Ports < NSPORT_RESERVED are reserved for privileged
  * processes (e.g. root).
  */
 #define NSPORT_RESERVED		3000

--- a/StdLib/Include/paths.h
+++ b/StdLib/Include/paths.h
@@ -85,7 +85,7 @@
 
 /* Resolver configuration file.
  * Normally not present, but may contain the address of the
- * inital name server(s) to query and the domain search list.
+ * initial name server(s) to query and the domain search list.
  */
 #define _PATH_RESCONF     _PATH_ETC "resolv.conf"
 #define _PATH_SERVICES    _PATH_ETC "services"

--- a/StdLib/Include/resolv.h
+++ b/StdLib/Include/resolv.h
@@ -91,7 +91,7 @@
 #define	RES_MAXNDOTS		15	/* should reflect bit field size */
 
 struct __res_state {
-	int	retrans;	 	/* retransmition time interval */
+	int	retrans;	 	/* retransmission time interval */
 	int	retry;			/* number of times to retransmit */
 	u_long	options;		/* option flags - see below. */
 	int	nscount;		/* number of name servers */

--- a/StdLib/Include/stdarg.h
+++ b/StdLib/Include/stdarg.h
@@ -103,7 +103,7 @@ typedef __builtin_va_list   va_list;
 /*@}*/
 
 /** @{
-    The va_end macro facillitates a normal return from the function whose
+    The va_end macro facilitates a normal return from the function whose
     variable argument list was referred to by the expansion of va_start that
     initialized the va_list ap.
 

--- a/StdLib/Include/stdio.h
+++ b/StdLib/Include/stdio.h
@@ -353,7 +353,7 @@ int       rename  (const char *OldName, const char *NewName);
 /** Create a guaranteed unique temporary file.
     A binary file is created in the _PATH_TMP directory that is guaranteed to
     have a unique name.  The file will be open for update with mode "wb+" and
-    its FILE pointer returned upon successfull completion.  When the file is
+    its FILE pointer returned upon successful completion.  When the file is
     closed, or when the creating program terminates, the file will be removed.
 
     @retval   NULL      The temporary file could not be created.

--- a/StdLib/Include/stdlib.h
+++ b/StdLib/Include/stdlib.h
@@ -872,7 +872,7 @@ size_t  wcstombs(char * __restrict Dest, const wchar_t * __restrict Src, size_t 
     @param[in]      file_name         The filename to convert.
     @param[in,out]  resolved_name     The resultant name.
 
-    @retval NULL                    An error occured.
+    @retval NULL                    An error occurred.
     @retval resolved_name.
 **/
 char * realpath(char *file_name, char *resolved_name);

--- a/StdLib/Include/sys/termios.h
+++ b/StdLib/Include/sys/termios.h
@@ -253,7 +253,7 @@ speed_t cfgetospeed (const struct termios *);
     @param[in]    NewSpeed  The new input baud rate.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EINVAL - The value of NewSpeed is outside the range of
                       possible speed values as specified in <sys/termios.h>.
 **/
@@ -269,7 +269,7 @@ int     cfsetispeed (struct termios *, speed_t);
     @param[in]    NewSpeed  The new output baud rate.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EINVAL - The value of NewSpeed is outside the range of
                       possible speed values as specified in <sys/termios.h>.
 **/
@@ -285,7 +285,7 @@ int     cfsetospeed (struct termios *, speed_t);
                             attributes of the interactive IO device.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EBADF - The fd argument is not a valid file descriptor.
                     * ENOTTY - The file associated with fd is not an interactive IO device.
 **/
@@ -311,7 +311,7 @@ int     tcgetattr   (int fd, struct termios *pTermios);
                           attributes to set in the interactive IO device.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EBADF - The fd argument is not a valid file descriptor.
                     * ENOTTY - The file associated with fd is not an interactive IO device.
 **/
@@ -323,7 +323,7 @@ int     tcsetattr   (int fd, int OptAct, const struct termios *pTermios);
     @param[in]  fd        The file descriptor for an open interactive IO device.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EBADF - The fd argument is not a valid file descriptor.
                     * ENOTTY - The file associated with fd is not an interactive IO device.
                     * EINTR - A signal interrupted tcdrain().
@@ -348,7 +348,7 @@ int     tcdrain     (int fd);
                                       terminal device to start transmitting data.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EBADF - The fd argument is not a valid file descriptor.
                     * ENOTTY - The file associated with fd is not an interactive IO device.
                     * EINVAL - The Action argument is not a supported value.
@@ -370,7 +370,7 @@ int     tcflow      (int fd, int Action);
                                     Otherwise error EINVAL.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EBADF - The fd argument is not a valid file descriptor.
                     * ENOTTY - The file associated with fd is not an interactive IO device.
                     * EINVAL - The QueueSelector argument is not a supported value.

--- a/StdLib/Include/sys/wait.h
+++ b/StdLib/Include/sys/wait.h
@@ -37,7 +37,7 @@
 #include <sys/types.h>
 
 /*
- * This file holds definitions relevent to the wait4 system call
+ * This file holds definitions relevant to the wait4 system call
  * and the alternate interfaces that use it (wait, wait3, waitpid).
  */
 

--- a/StdLib/Include/wchar.h
+++ b/StdLib/Include/wchar.h
@@ -777,7 +777,7 @@ int vfwscanf(FILE * __restrict Stream, const wchar_t * __restrict Format, va_lis
 
     @return   The vswprintf function returns the number of wide characters
               written in the array, not counting the terminating null wide
-              character, or a neg ative value if an encoding error occurred or
+              character, or a negative value if an encoding error occurred or
               if n or more wide characters were requested to be generated.
 **/
 int vswprintf(wchar_t * __restrict S, size_t N, const wchar_t * __restrict Format, va_list Args);

--- a/StdLib/LibC/Ctype/CClass.c
+++ b/StdLib/LibC/Ctype/CClass.c
@@ -241,7 +241,7 @@ isblank(
 
   @param[in]  c   The character to test.
 
-  @return     Returns nonzero (true) if c is a valid ASCII character.  Otherwize,
+  @return     Returns nonzero (true) if c is a valid ASCII character.  Otherwise,
               zero (false) is returned.
 **/
 int

--- a/StdLib/LibC/LibC.inf
+++ b/StdLib/LibC/LibC.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Standard C library: Miscelaneous implementations.
+#  Standard C library: Miscellaneous implementations.
 #
 #  Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
 #

--- a/StdLib/LibC/Locale/localeconv.c
+++ b/StdLib/LibC/Locale/localeconv.c
@@ -18,7 +18,7 @@ __RCSID("$NetBSD: localeconv.c,v 1.13 2005/11/29 03:11:59 christos Exp $");
  * monetary and numeric locales.
  *
  * Because localeconv() may be called many times (especially by library
- * routines like printf() & strtod()), the approprate members of the
+ * routines like printf() & strtod()), the appropriate members of the
  * lconv structure are computed only when the monetary or numeric
  * locale has been changed.
  */

--- a/StdLib/LibC/Main/Arm/flt_rounds.c
+++ b/StdLib/LibC/Main/Arm/flt_rounds.c
@@ -52,7 +52,7 @@ static const int map[] = {
  * Returns:
  *  0 - round to zero
  *  1 - round to nearest
- *  2 - round to postive infinity
+ *  2 - round to positive infinity
  *  3 - round to negative infinity
  *
  * ok all we need to do is get the current FP rounding mode

--- a/StdLib/LibC/Main/isinfd_ieee754.c
+++ b/StdLib/LibC/Main/isinfd_ieee754.c
@@ -47,7 +47,7 @@ __RCSID("$NetBSD: isinfd_ieee754.c,v 1.1 2004/03/04 23:42:39 kleink Exp $");
 #include <machine/ieee.h>
 #include <math.h>
 
-/* libc.so.12 ABI compatbility */
+/* libc.so.12 ABI compatibility */
 #ifdef __weak_alias
 __weak_alias(isinf,__isinfd)
 #endif

--- a/StdLib/LibC/Main/isnand_ieee754.c
+++ b/StdLib/LibC/Main/isnand_ieee754.c
@@ -47,7 +47,7 @@ __RCSID("$NetBSD: isnand_ieee754.c,v 1.1 2004/03/04 23:42:39 kleink Exp $");
 #include <machine/ieee.h>
 #include <math.h>
 
-/* libc.so.12 ABI compatbility */
+/* libc.so.12 ABI compatibility */
 #ifdef __weak_alias
 __weak_alias(isnan,__isnand)
 #endif

--- a/StdLib/LibC/Math/e_cosh.c
+++ b/StdLib/LibC/Math/e_cosh.c
@@ -77,7 +77,7 @@ __ieee754_cosh(double x)
     /* |x| in [22, log(maxdouble)] return half*exp(|x|) */
   if (ix < 0x40862E42)  return half*__ieee754_exp(fabs(x));
 
-    /* |x| in [log(maxdouble), overflowthresold] */
+    /* |x| in [log(maxdouble), overflowthreshold] */
   GET_LOW_WORD(lx,x);
   if (ix<0x408633CE ||
         ((ix==0x408633ce)&&(lx<=(u_int32_t)0x8fb9f87d))) {
@@ -86,6 +86,6 @@ __ieee754_cosh(double x)
       return t*w;
   }
 
-    /* |x| > overflowthresold, cosh(x) overflow */
+    /* |x| > overflowthreshold, cosh(x) overflow */
   return huge*huge;
 }

--- a/StdLib/LibC/Math/e_log.c
+++ b/StdLib/LibC/Math/e_log.c
@@ -1,5 +1,5 @@
 /** @file
-  Compute the logrithm of x.
+  Compute the logarithm of x.
 
   Copyright (c) 2010 - 2011, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials are licensed and made available under
@@ -31,7 +31,7 @@
 #endif
 
 /* __ieee754_log(x)
- * Return the logrithm of x
+ * Return the logarithm of x
  *
  * Method :
  *   1. Argument Reduction: find k and f such that

--- a/StdLib/LibC/Math/e_log10.c
+++ b/StdLib/LibC/Math/e_log10.c
@@ -1,5 +1,5 @@
 /** @file
-  Compute the base 10 logrithm of x.
+  Compute the base 10 logarithm of x.
 
   Copyright (c) 2010 - 2011, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials are licensed and made available under

--- a/StdLib/LibC/Math/e_pow.c
+++ b/StdLib/LibC/Math/e_pow.c
@@ -1,5 +1,5 @@
 /** @file
-  Compute the base 10 logrithm of x.
+  Compute the base 10 logarithm of x.
 
   Copyright (c) 2010 - 2011, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials are licensed and made available under

--- a/StdLib/LibC/Math/e_sinh.c
+++ b/StdLib/LibC/Math/e_sinh.c
@@ -66,7 +66,7 @@ __ieee754_sinh(double x)
     /* |x| in [22, log(maxdouble)] return 0.5*exp(|x|) */
   if (ix < 0x40862E42)  return h*__ieee754_exp(fabs(x));
 
-    /* |x| in [log(maxdouble), overflowthresold] */
+    /* |x| in [log(maxdouble), overflowthreshold] */
   GET_LOW_WORD(lx,x);
   if (ix<0x408633CE || ((ix==0x408633ce)&&(lx<=(u_int32_t)0x8fb9f87d))) {
       w = __ieee754_exp(0.5*fabs(x));
@@ -74,6 +74,6 @@ __ieee754_sinh(double x)
       return t*w;
   }
 
-    /* |x| > overflowthresold, sinh(x) overflow */
+    /* |x| > overflowthreshold, sinh(x) overflow */
   return x*shuge;
 }

--- a/StdLib/LibC/Math/e_sqrt.c
+++ b/StdLib/LibC/Math/e_sqrt.c
@@ -1,5 +1,5 @@
 /** @file
-  Compute the logrithm of x.
+  Compute the logarithm of x.
 
   Copyright (c) 2010 - 2011, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials are licensed and made available under
@@ -62,7 +62,7 @@
  *  If (2) is false, then q   = q ; otherwise q   = q  + 2      .
  *             i+1   i             i+1   i
  *
- *  With some algebric manipulation, it is not difficult to see
+ *  With some algebraic manipulation, it is not difficult to see
  *  that (2) is equivalent to
  *                             -(i+1)
  *      s  +  2       <= y      (3)
@@ -286,7 +286,7 @@ A.  sqrt(x) by Newton Iteration
   This formula has one division fewer than the one above; however,
   it requires more multiplications and additions. Also x must be
   scaled in advance to avoid spurious overflow in evaluating the
-  expression 3y*y+x. Hence it is not recommended uless division
+  expression 3y*y+x. Hence it is not recommended unless division
   is slow. If division is very slow, then one should use the
   reciproot algorithm given in section B.
 

--- a/StdLib/LibC/Math/k_rem_pio2.c
+++ b/StdLib/LibC/Math/k_rem_pio2.c
@@ -53,7 +53,7 @@ __RCSID("$NetBSD: k_rem_pio2.c,v 1.11 2003/01/04 23:43:03 wiz Exp $");
  *      64-bit  precision 2
  *      113-bit precision 3
  *    The actual value is the sum of them. Thus for 113-bit
- *    precison, one may have to do something like:
+ *    precision, one may have to do something like:
  *
  *    long double t,w,r_head, r_tail;
  *    t = (long double)y[2] + (long double)y[1];

--- a/StdLib/LibC/Softfloat/timesoftfloat.txt
+++ b/StdLib/LibC/Softfloat/timesoftfloat.txt
@@ -59,7 +59,7 @@ of usage is written.  It is also possible to evaluate all machine functions
 in a single invocation as explained in the section _Function_Sets_ later in
 this document.
 
-Ordinarily, a function's speed will be evaulated separately for each of
+Ordinarily, a function's speed will be evaluated separately for each of
 the four rounding modes, one after the other.  If the rounding mode is not
 supposed to have any affect on the results of a function--for instance,
 some operations do not require rounding--only the nearest/even rounding mode

--- a/StdLib/LibC/StdLib/realpath.c
+++ b/StdLib/LibC/StdLib/realpath.c
@@ -28,7 +28,7 @@
   @param[in] file_name            The filename to convert.
   @param[in,out] resolved_name    The resultant name.
 
-  @retval NULL                    An error occured.
+  @retval NULL                    An error occurred.
   @return resolved_name.
 **/
 char *

--- a/StdLib/LibC/String/String.inf
+++ b/StdLib/LibC/String/String.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Standard C library: Miscelaneous implementations.
+#  Standard C library: Miscellaneous implementations.
 #
 #  Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
 #

--- a/StdLib/LibC/Time/Theory.txt
+++ b/StdLib/LibC/Time/Theory.txt
@@ -188,7 +188,7 @@ among the following goals:
    agreed since 1970.  This is essential for the intended use: static
    clocks keeping local civil time.
 
- * Indicate to humans as to where that region is.  This simplifes use.
+ * Indicate to humans as to where that region is.  This simplifies use.
 
  * Be robust in the presence of political changes.  This reduces the
    number of updates and backward-compatibility hacks.  For example,

--- a/StdLib/LibC/Time/timegm.c
+++ b/StdLib/LibC/Time/timegm.c
@@ -76,14 +76,14 @@ static char *sccsid = "from: @(#)ctime.c	5.26 (Berkeley) 2/23/91";
 #include  <time.h>
 
 /*
-  This funciton is in Time.c, which has a different license than timegm.
+  This function is in Time.c, which has a different license than timegm.
 */
 time_t 
 time2(struct tm * const tmp, void (* const funcp)(const time_t*, long, struct tm*),
       const long offset, int * const okayp);
 
 /*
-  This funciton is in Time.c, which has a different license than timegm.
+  This function is in Time.c, which has a different license than timegm.
 */
 void
 gmtsub(

--- a/StdLib/LibC/Uefi/Devices/Console/daConsole.c
+++ b/StdLib/LibC/Uefi/Devices/Console/daConsole.c
@@ -7,7 +7,7 @@
   characters.  It this the responsibility of the caller to convert between
   narrow and wide characters in order to perform the desired operations.
 
-  The devices status as a wide device is indicatd by _S_IWTTY being set in
+  The devices status as a wide device is indicated by _S_IWTTY being set in
   f_iflags.
 
   Copyright (c) 2016, Daryl McDaniel. All rights reserved.<BR>

--- a/StdLib/LibC/Uefi/InteractiveIO/TerminalFunctions.c
+++ b/StdLib/LibC/Uefi/InteractiveIO/TerminalFunctions.c
@@ -68,7 +68,7 @@ cfgetospeed (
     @param[in]    NewSpeed  The new input baud rate.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EINVAL - The value of NewSpeed is outside the range of
                       possible speed values as specified in <sys/termios.h>.
 **/
@@ -101,7 +101,7 @@ cfsetispeed (
     @param[in]    NewSpeed  The new output baud rate.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EINVAL - The value of NewSpeed is outside the range of
                       possible speed values as specified in <sys/termios.h>.
 **/
@@ -134,7 +134,7 @@ cfsetospeed (
                             attributes of the interactive IO device.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EBADF - The fd argument is not a valid file descriptor.
                     * ENOTTY - The file associated with fd is not an interactive IO device.
 **/
@@ -191,7 +191,7 @@ tcgetattr (
                           attributes to set in the interactive IO device.
 
     @retval 0     The operation completed successfully.
-    @retval -1    An error occured and errno is set to indicate the error.
+    @retval -1    An error occurred and errno is set to indicate the error.
                     * EBADF - The fd argument is not a valid file descriptor.
                     * ENOTTY - The file associated with fd is not an interactive IO device.
 **/

--- a/StdLib/LibC/Uefi/SysCalls.c
+++ b/StdLib/LibC/Uefi/SysCalls.c
@@ -910,7 +910,7 @@ poll (
     @param[in]  To      The new name of From.
 
     @retval   0     Successful completion.
-    @retval   -1    An error has occured and errno has been set to further specify the error.
+    @retval   -1    An error has occurred and errno has been set to further specify the error.
                     Neither the file named by From nor the file named by To are
                     changed or created.
                       - ENXIO: Path specified is not supported by any loaded driver.
@@ -951,7 +951,7 @@ rename(
     @param[in]  path    Path to the directory to delete.
 
     @retval   -1    The directory couldn't be opened (doesn't exist).
-    @retval   -1    The directory wasn't empty or an IO error occured.
+    @retval   -1    The directory wasn't empty or an IO error occurred.
 **/
 int
 rmdir(
@@ -1072,7 +1072,7 @@ lstat (const char *path, struct stat *statbuf)
     @param[in,out]    ...       Zero or more parameters as required for request.
 
     @retval   >=0   The operation completed successfully.
-    @retval   -1    An error occured.  More information is in errno.
+    @retval   -1    An error occurred.  More information is in errno.
 **/
 int
 ioctl(
@@ -1436,7 +1436,7 @@ va_Utimes(
     @param[in]  times   Pointer to an array of two timeval structures
 
     @retval   0     File times successfully set.
-    @retval   -1    An error occured.  Error type in errno.
+    @retval   -1    An error occurred.  Error type in errno.
 **/
 int
 utimes(

--- a/StdLib/LibC/Uefi/compat.c
+++ b/StdLib/LibC/Uefi/compat.c
@@ -633,7 +633,7 @@ fmtint(char *buffer, size_t *currlen, size_t maxlen,
     spadlen = 0;
   }
   if (flags & DP_F_MINUS)
-    spadlen = -spadlen; /* Left Justifty */
+    spadlen = -spadlen; /* Left Justify */
 
   /* Spaces */
   while (spadlen > 0) {
@@ -765,7 +765,7 @@ fmtfp(char *buffer, size_t *currlen, size_t maxlen, long double fvalue,
   if (padlen < 0)
     padlen = 0;
   if (flags & DP_F_MINUS)
-    padlen = -padlen; /* Left Justifty */
+    padlen = -padlen; /* Left Justify */
 
   if ((flags & DP_F_ZERO) && (padlen > 0)) {
     if (signvalue) {

--- a/StdLib/LibC/Wchar/String.c
+++ b/StdLib/LibC/Wchar/String.c
@@ -1,5 +1,5 @@
 /** @file
-    Miscelaneous Functions for <wchar.h>.
+    Miscellaneous Functions for <wchar.h>.
 
   Unless explicitly stated otherwise, if the execution of a function declared
   in this file causes copying to take place between objects that overlap, the

--- a/StdLib/LibC/Wchar/Wchar.inf
+++ b/StdLib/LibC/Wchar/Wchar.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Standard C library: Miscelaneous implementations.
+#  Standard C library: Miscellaneous implementations.
 #
 #  Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
 #

--- a/StdLib/LibC/gdtoa/gdtoaimp.h
+++ b/StdLib/LibC/gdtoa/gdtoaimp.h
@@ -1,5 +1,5 @@
 /** @file
-  This is a variation on dtoa.c that converts arbitary binary
+  This is a variation on dtoa.c that converts arbitrary binary
   floating-point formats to and from decimal notation.  It uses
   double-precision arithmetic internally, so there are still
   various #ifdefs that adapt the calculations to the native

--- a/StdLib/PosixLib/Gen/dirname.c
+++ b/StdLib/PosixLib/Gen/dirname.c
@@ -70,7 +70,7 @@ dirname(char *path)
   while (lastp != path && isDirSep(*lastp))
     lastp--;
 
-  /* Terminate path at the last occurence of '/'. */
+  /* Terminate path at the last occurrence of '/'. */
   do {
     if (isDirSep(*lastp)) {
       /* Strip trailing slashes, if any. */

--- a/StdLib/ReadMe.txt
+++ b/StdLib/ReadMe.txt
@@ -409,7 +409,7 @@ Note that the set of BuildOptions used is determined by the state of the EMULATE
   !else
     # The Build Options, below, are only used when building the Standard Libraries
     # to be run under an emulation environment.
-    # They disable optimization which facillitates debugging under the Emulation environment.
+    # They disable optimization which facilitates debugging under the Emulation environment.
     INTEL:*_*_IA32_CC_FLAGS  = /Od
      MSFT:*_*_IA32_CC_FLAGS  = /Od
       GCC:*_*_IA32_CC_FLAGS  = -O0

--- a/StdLib/SocketDxe/EntryUnload.c
+++ b/StdLib/SocketDxe/EntryUnload.c
@@ -282,7 +282,7 @@ EntryPoint (
       EslServiceLoad ( ImageHandle );
 
       //
-      //  Make the socket serivces available to other drivers
+      //  Make the socket services available to other drivers
       //  and applications
       //
       Status = EslDxeInstall ( &ImageHandle );
@@ -328,7 +328,7 @@ EntryPoint (
 
 
 /**
-  Socket layer's service binding protocol delcaration.
+  Socket layer's service binding protocol declaration.
 **/
 CONST EFI_SERVICE_BINDING_PROTOCOL mEfiServiceBinding = {
   EslDxeCreateChild,

--- a/StdLib/SocketDxe/Socket.h
+++ b/StdLib/SocketDxe/Socket.h
@@ -20,7 +20,7 @@
 extern EFI_COMPONENT_NAME_PROTOCOL mComponentName;    ///<  Component name protocol declaration
 extern EFI_COMPONENT_NAME2_PROTOCOL mComponentName2;  ///<  Component name 2 protocol declaration
 extern EFI_DRIVER_BINDING_PROTOCOL mDriverBinding;    ///<  Driver binding protocol declaration
-extern EFI_SERVICE_BINDING_PROTOCOL mServiceBinding;  ///<  Service binding protocol delcaration
+extern EFI_SERVICE_BINDING_PROTOCOL mServiceBinding;  ///<  Service binding protocol declaration
 
 //------------------------------------------------------------------------------
 // Driver Binding Protocol Support

--- a/StdLib/StdLib.inc
+++ b/StdLib/StdLib.inc
@@ -112,7 +112,7 @@
 !ifdef $(EMULATE)
   # The Build Options, below, are only used when building the Standard Libraries
   # to be run under an emulation environment; such as NT32Pkg.
-  # They disable optimization which facillitates debugging under the Emulation environment.
+  # They disable optimization which facilitates debugging under the Emulation environment.
   INTEL:*_*_IA32_CC_FLAGS   = /Od /D UEFI_C_SOURCE
    MSFT:*_*_IA32_CC_FLAGS   = /Od /D UEFI_C_SOURCE
     GCC:*_*_IA32_CC_FLAGS   = -O0 -DUEFI_C_SOURCE

--- a/StdLibPrivateInternalFiles/Include/reentrant.h
+++ b/StdLibPrivateInternalFiles/Include/reentrant.h
@@ -72,7 +72,7 @@
  * Implementation Details:
  * 
  * The thread primitives used by the library (mutex_t, mutex_lock, etc.)
- * are macros which expand to the cooresponding primitives provided by
+ * are macros which expand to the corresponding primitives provided by
  * the thread engine or to nothing.  The latter is used so that code is
  * not unreasonably cluttered with #ifdefs when all thread safe support
  * is removed.

--- a/StdLibPrivateInternalFiles/ReadMe.txt
+++ b/StdLibPrivateInternalFiles/ReadMe.txt
@@ -395,7 +395,7 @@ Note that the set of BuildOptions used is determined by the state of the EMULATE
   !else
     # The Build Options, below, are only used when building the Standard Libraries
     # to be run under an emulation environment.
-    # They disable optimization which facillitates debugging under the Emulation environment.
+    # They disable optimization which facilitates debugging under the Emulation environment.
     INTEL:*_*_IA32_CC_FLAGS  = /Od
      MSFT:*_*_IA32_CC_FLAGS  = /Od
       GCC:*_*_IA32_CC_FLAGS  = -O0


### PR DESCRIPTION
Fix various typos in StdLib.

This is actually a cherry pick of a larger change updated since 2018 at https://github.com/Coeur/edk2/commit/1ee272df2d093236de8a3da14e2c3960a7e8d3eb.
