### PR TITLE
Additions to StdLib

### DIFF
--- a/StdLib/Include/Aarch64/machine/int_fmtio.h
+++ b/StdLib/Include/Aarch64/machine/int_fmtio.h
@@ -1,0 +1,211 @@
+/*	$NetBSD: int_fmtio.h,v 1.10 2018/07/15 00:36:13 christos Exp $	*/
+
+/*-
+ * Copyright (c) 2001 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Klaus Klein.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _ARM_INT_FMTIO_H_
+#define _ARM_INT_FMTIO_H_
+
+/*
+ * 7.8.1 Macros for format specifiers
+ */
+
+/* fprintf macros for signed integers */
+#define	PRId8		"d"	/* int8_t		*/
+#define	PRId16		"d"	/* int16_t		*/
+#define	PRId32		"d"	/* int32_t		*/
+#define	PRId64		"lld"	/* int64_t		*/
+#define	PRIdLEAST8	"d"	/* int_least8_t		*/
+#define	PRIdLEAST16	"d"	/* int_least16_t	*/
+#define	PRIdLEAST32	"d"	/* int_least32_t	*/
+#define	PRIdLEAST64	"lld"	/* int_least64_t	*/
+#define	PRIdFAST8	"d"	/* int_fast8_t		*/
+#define	PRIdFAST16	"d"	/* int_fast16_t		*/
+#define	PRIdFAST32	"d"	/* int_fast32_t		*/
+#define	PRIdFAST64	"lld"	/* int_fast64_t		*/
+#define	PRIdMAX		"lld"	/* intmax_t		*/
+#define	PRIdPTR		"ld"	/* intptr_t		*/
+
+#define	PRIi8		"i"	/* int8_t		*/
+#define	PRIi16		"i"	/* int16_t		*/
+#define	PRIi32		"i"	/* int32_t		*/
+#define	PRIi64		"lli"	/* int64_t		*/
+#define	PRIiLEAST8	"i"	/* int_least8_t		*/
+#define	PRIiLEAST16	"i"	/* int_least16_t	*/
+#define	PRIiLEAST32	"i"	/* int_least32_t	*/
+#define	PRIiLEAST64	"lli"	/* int_least64_t	*/
+#define	PRIiFAST8	"i"	/* int_fast8_t		*/
+#define	PRIiFAST16	"i"	/* int_fast16_t		*/
+#define	PRIiFAST32	"i"	/* int_fast32_t		*/
+#define	PRIiFAST64	"lli"	/* int_fast64_t		*/
+#define	PRIiMAX		"lli"	/* intmax_t		*/
+#define	PRIiPTR		"li"	/* intptr_t		*/
+
+/* fprintf macros for unsigned integers */
+
+#define	PRIo8		"o"	/* uint8_t		*/
+#define	PRIo16		"o"	/* uint16_t		*/
+#define	PRIo32		"o"	/* uint32_t		*/
+#define	PRIo64		"llo"	/* uint64_t		*/
+#define	PRIoLEAST8	"o"	/* uint_least8_t	*/
+#define	PRIoLEAST16	"o"	/* uint_least16_t	*/
+#define	PRIoLEAST32	"o"	/* uint_least32_t	*/
+#define	PRIoLEAST64	"llo"	/* uint_least64_t	*/
+#define	PRIoFAST8	"o"	/* uint_fast8_t		*/
+#define	PRIoFAST16	"o"	/* uint_fast16_t	*/
+#define	PRIoFAST32	"o"	/* uint_fast32_t	*/
+#define	PRIoFAST64	"llo"	/* uint_fast64_t	*/
+#define	PRIoMAX		"llo"	/* uintmax_t		*/
+#define	PRIoPTR		"lo"	/* uintptr_t		*/
+
+#define	PRIu8		"u"	/* uint8_t		*/
+#define	PRIu16		"u"	/* uint16_t		*/
+#define	PRIu32		"u"	/* uint32_t		*/
+#define	PRIu64		"llu"	/* uint64_t		*/
+#define	PRIuLEAST8	"u"	/* uint_least8_t	*/
+#define	PRIuLEAST16	"u"	/* uint_least16_t	*/
+#define	PRIuLEAST32	"u"	/* uint_least32_t	*/
+#define	PRIuLEAST64	"llu"	/* uint_least64_t	*/
+#define	PRIuFAST8	"u"	/* uint_fast8_t		*/
+#define	PRIuFAST16	"u"	/* uint_fast16_t	*/
+#define	PRIuFAST32	"u"	/* uint_fast32_t	*/
+#define	PRIuFAST64	"llu"	/* uint_fast64_t	*/
+#define	PRIuMAX		"llu"	/* uintmax_t		*/
+#define	PRIuPTR		"lu"	/* uintptr_t		*/
+
+#define	PRIx8		"x"	/* uint8_t		*/
+#define	PRIx16		"x"	/* uint16_t		*/
+#define	PRIx32		"x"	/* uint32_t		*/
+#define	PRIx64		"llx"	/* uint64_t		*/
+#define	PRIxLEAST8	"x"	/* uint_least8_t	*/
+#define	PRIxLEAST16	"x"	/* uint_least16_t	*/
+#define	PRIxLEAST32	"x"	/* uint_least32_t	*/
+#define	PRIxLEAST64	"llx"	/* uint_least64_t	*/
+#define	PRIxFAST8	"x"	/* uint_fast8_t		*/
+#define	PRIxFAST16	"x"	/* uint_fast16_t	*/
+#define	PRIxFAST32	"x"	/* uint_fast32_t	*/
+#define	PRIxFAST64	"llx"	/* uint_fast64_t	*/
+#define	PRIxMAX		"llx"	/* uintmax_t		*/
+#define	PRIxPTR		"lx"	/* uintptr_t		*/
+
+#define	PRIX8		"X"	/* uint8_t		*/
+#define	PRIX16		"X"	/* uint16_t		*/
+#define	PRIX32		"X"	/* uint32_t		*/
+#define	PRIX64		"llX"	/* uint64_t		*/
+#define	PRIXLEAST8	"X"	/* uint_least8_t	*/
+#define	PRIXLEAST16	"X"	/* uint_least16_t	*/
+#define	PRIXLEAST32	"X"	/* uint_least32_t	*/
+#define	PRIXLEAST64	"llX"	/* uint_least64_t	*/
+#define	PRIXFAST8	"X"	/* uint_fast8_t		*/
+#define	PRIXFAST16	"X"	/* uint_fast16_t	*/
+#define	PRIXFAST32	"X"	/* uint_fast32_t	*/
+#define	PRIXFAST64	"llX"	/* uint_fast64_t	*/
+#define	PRIXMAX		"llX"	/* uintmax_t		*/
+#define	PRIXPTR		"lX"	/* uintptr_t		*/
+
+/* fscanf macros for signed integers */
+
+#define	SCNd8		"hhd"	/* int8_t		*/
+#define	SCNd16		"hd"	/* int16_t		*/
+#define	SCNd32		"d"	/* int32_t		*/
+#define	SCNd64		"lld"	/* int64_t		*/
+#define	SCNdLEAST8	"hhd"	/* int_least8_t		*/
+#define	SCNdLEAST16	"hd"	/* int_least16_t	*/
+#define	SCNdLEAST32	"d"	/* int_least32_t	*/
+#define	SCNdLEAST64	"lld"	/* int_least64_t	*/
+#define	SCNdFAST8	"d"	/* int_fast8_t		*/
+#define	SCNdFAST16	"d"	/* int_fast16_t		*/
+#define	SCNdFAST32	"d"	/* int_fast32_t		*/
+#define	SCNdFAST64	"lld"	/* int_fast64_t		*/
+#define	SCNdMAX		"lld"	/* intmax_t		*/
+#define	SCNdPTR		"ld"	/* intptr_t		*/
+
+#define	SCNi8		"hhi"	/* int8_t		*/
+#define	SCNi16		"hi"	/* int16_t		*/
+#define	SCNi32		"i"	/* int32_t		*/
+#define	SCNi64		"lli"	/* int64_t		*/
+#define	SCNiLEAST8	"hhi"	/* int_least8_t		*/
+#define	SCNiLEAST16	"hi"	/* int_least16_t	*/
+#define	SCNiLEAST32	"i"	/* int_least32_t	*/
+#define	SCNiLEAST64	"lli"	/* int_least64_t	*/
+#define	SCNiFAST8	"i"	/* int_fast8_t		*/
+#define	SCNiFAST16	"i"	/* int_fast16_t		*/
+#define	SCNiFAST32	"i"	/* int_fast32_t		*/
+#define	SCNiFAST64	"lli"	/* int_fast64_t		*/
+#define	SCNiMAX		"lli"	/* intmax_t		*/
+#define	SCNiPTR		"li"	/* intptr_t		*/
+
+/* fscanf macros for unsigned integers */
+
+#define	SCNo8		"hho"	/* uint8_t		*/
+#define	SCNo16		"ho"	/* uint16_t		*/
+#define	SCNo32		"o"	/* uint32_t		*/
+#define	SCNo64		"llo"	/* uint64_t		*/
+#define	SCNoLEAST8	"hho"	/* uint_least8_t	*/
+#define	SCNoLEAST16	"ho"	/* uint_least16_t	*/
+#define	SCNoLEAST32	"o"	/* uint_least32_t	*/
+#define	SCNoLEAST64	"llo"	/* uint_least64_t	*/
+#define	SCNoFAST8	"o"	/* uint_fast8_t		*/
+#define	SCNoFAST16	"o"	/* uint_fast16_t	*/
+#define	SCNoFAST32	"o"	/* uint_fast32_t	*/
+#define	SCNoFAST64	"llo"	/* uint_fast64_t	*/
+#define	SCNoMAX		"llo"	/* uintmax_t		*/
+#define	SCNoPTR		"lo"	/* uintptr_t		*/
+
+#define	SCNu8		"hhu"	/* uint8_t		*/
+#define	SCNu16		"hu"	/* uint16_t		*/
+#define	SCNu32		"u"	/* uint32_t		*/
+#define	SCNu64		"llu"	/* uint64_t		*/
+#define	SCNuLEAST8	"hhu"	/* uint_least8_t	*/
+#define	SCNuLEAST16	"hu"	/* uint_least16_t	*/
+#define	SCNuLEAST32	"u"	/* uint_least32_t	*/
+#define	SCNuLEAST64	"llu"	/* uint_least64_t	*/
+#define	SCNuFAST8	"u"	/* uint_fast8_t		*/
+#define	SCNuFAST16	"u"	/* uint_fast16_t	*/
+#define	SCNuFAST32	"u"	/* uint_fast32_t	*/
+#define	SCNuFAST64	"llu"	/* uint_fast64_t	*/
+#define	SCNuMAX		"llu"	/* uintmax_t		*/
+#define	SCNuPTR		"lu"	/* uintptr_t		*/
+
+#define	SCNx8		"hhx"	/* uint8_t		*/
+#define	SCNx16		"hx"	/* uint16_t		*/
+#define	SCNx32		"x"	/* uint32_t		*/
+#define	SCNx64		"llx"	/* uint64_t		*/
+#define	SCNxLEAST8	"hhx"	/* uint_least8_t	*/
+#define	SCNxLEAST16	"hx"	/* uint_least16_t	*/
+#define	SCNxLEAST32	"x"	/* uint_least32_t	*/
+#define	SCNxLEAST64	"llx"	/* uint_least64_t	*/
+#define	SCNxFAST8	"x"	/* uint_fast8_t		*/
+#define	SCNxFAST16	"x"	/* uint_fast16_t	*/
+#define	SCNxFAST32	"x"	/* uint_fast32_t	*/
+#define	SCNxFAST64	"llx"	/* uint_fast64_t	*/
+#define	SCNxMAX		"llx"	/* uintmax_t		*/
+#define	SCNxPTR		"lx"	/* uintptr_t		*/
+
+#endif /* !_ARM_INT_FMTIO_H_ */

--- a/StdLib/Include/Arm/machine/int_fmtio.h
+++ b/StdLib/Include/Arm/machine/int_fmtio.h
@@ -1,0 +1,211 @@
+/*	$NetBSD: int_fmtio.h,v 1.10 2018/07/15 00:36:13 christos Exp $	*/
+
+/*-
+ * Copyright (c) 2001 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Klaus Klein.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _ARM_INT_FMTIO_H_
+#define _ARM_INT_FMTIO_H_
+
+/*
+ * 7.8.1 Macros for format specifiers
+ */
+
+/* fprintf macros for signed integers */
+#define	PRId8		"d"	/* int8_t		*/
+#define	PRId16		"d"	/* int16_t		*/
+#define	PRId32		"d"	/* int32_t		*/
+#define	PRId64		"lld"	/* int64_t		*/
+#define	PRIdLEAST8	"d"	/* int_least8_t		*/
+#define	PRIdLEAST16	"d"	/* int_least16_t	*/
+#define	PRIdLEAST32	"d"	/* int_least32_t	*/
+#define	PRIdLEAST64	"lld"	/* int_least64_t	*/
+#define	PRIdFAST8	"d"	/* int_fast8_t		*/
+#define	PRIdFAST16	"d"	/* int_fast16_t		*/
+#define	PRIdFAST32	"d"	/* int_fast32_t		*/
+#define	PRIdFAST64	"lld"	/* int_fast64_t		*/
+#define	PRIdMAX		"lld"	/* intmax_t		*/
+#define	PRIdPTR		"ld"	/* intptr_t		*/
+
+#define	PRIi8		"i"	/* int8_t		*/
+#define	PRIi16		"i"	/* int16_t		*/
+#define	PRIi32		"i"	/* int32_t		*/
+#define	PRIi64		"lli"	/* int64_t		*/
+#define	PRIiLEAST8	"i"	/* int_least8_t		*/
+#define	PRIiLEAST16	"i"	/* int_least16_t	*/
+#define	PRIiLEAST32	"i"	/* int_least32_t	*/
+#define	PRIiLEAST64	"lli"	/* int_least64_t	*/
+#define	PRIiFAST8	"i"	/* int_fast8_t		*/
+#define	PRIiFAST16	"i"	/* int_fast16_t		*/
+#define	PRIiFAST32	"i"	/* int_fast32_t		*/
+#define	PRIiFAST64	"lli"	/* int_fast64_t		*/
+#define	PRIiMAX		"lli"	/* intmax_t		*/
+#define	PRIiPTR		"li"	/* intptr_t		*/
+
+/* fprintf macros for unsigned integers */
+
+#define	PRIo8		"o"	/* uint8_t		*/
+#define	PRIo16		"o"	/* uint16_t		*/
+#define	PRIo32		"o"	/* uint32_t		*/
+#define	PRIo64		"llo"	/* uint64_t		*/
+#define	PRIoLEAST8	"o"	/* uint_least8_t	*/
+#define	PRIoLEAST16	"o"	/* uint_least16_t	*/
+#define	PRIoLEAST32	"o"	/* uint_least32_t	*/
+#define	PRIoLEAST64	"llo"	/* uint_least64_t	*/
+#define	PRIoFAST8	"o"	/* uint_fast8_t		*/
+#define	PRIoFAST16	"o"	/* uint_fast16_t	*/
+#define	PRIoFAST32	"o"	/* uint_fast32_t	*/
+#define	PRIoFAST64	"llo"	/* uint_fast64_t	*/
+#define	PRIoMAX		"llo"	/* uintmax_t		*/
+#define	PRIoPTR		"lo"	/* uintptr_t		*/
+
+#define	PRIu8		"u"	/* uint8_t		*/
+#define	PRIu16		"u"	/* uint16_t		*/
+#define	PRIu32		"u"	/* uint32_t		*/
+#define	PRIu64		"llu"	/* uint64_t		*/
+#define	PRIuLEAST8	"u"	/* uint_least8_t	*/
+#define	PRIuLEAST16	"u"	/* uint_least16_t	*/
+#define	PRIuLEAST32	"u"	/* uint_least32_t	*/
+#define	PRIuLEAST64	"llu"	/* uint_least64_t	*/
+#define	PRIuFAST8	"u"	/* uint_fast8_t		*/
+#define	PRIuFAST16	"u"	/* uint_fast16_t	*/
+#define	PRIuFAST32	"u"	/* uint_fast32_t	*/
+#define	PRIuFAST64	"llu"	/* uint_fast64_t	*/
+#define	PRIuMAX		"llu"	/* uintmax_t		*/
+#define	PRIuPTR		"lu"	/* uintptr_t		*/
+
+#define	PRIx8		"x"	/* uint8_t		*/
+#define	PRIx16		"x"	/* uint16_t		*/
+#define	PRIx32		"x"	/* uint32_t		*/
+#define	PRIx64		"llx"	/* uint64_t		*/
+#define	PRIxLEAST8	"x"	/* uint_least8_t	*/
+#define	PRIxLEAST16	"x"	/* uint_least16_t	*/
+#define	PRIxLEAST32	"x"	/* uint_least32_t	*/
+#define	PRIxLEAST64	"llx"	/* uint_least64_t	*/
+#define	PRIxFAST8	"x"	/* uint_fast8_t		*/
+#define	PRIxFAST16	"x"	/* uint_fast16_t	*/
+#define	PRIxFAST32	"x"	/* uint_fast32_t	*/
+#define	PRIxFAST64	"llx"	/* uint_fast64_t	*/
+#define	PRIxMAX		"llx"	/* uintmax_t		*/
+#define	PRIxPTR		"lx"	/* uintptr_t		*/
+
+#define	PRIX8		"X"	/* uint8_t		*/
+#define	PRIX16		"X"	/* uint16_t		*/
+#define	PRIX32		"X"	/* uint32_t		*/
+#define	PRIX64		"llX"	/* uint64_t		*/
+#define	PRIXLEAST8	"X"	/* uint_least8_t	*/
+#define	PRIXLEAST16	"X"	/* uint_least16_t	*/
+#define	PRIXLEAST32	"X"	/* uint_least32_t	*/
+#define	PRIXLEAST64	"llX"	/* uint_least64_t	*/
+#define	PRIXFAST8	"X"	/* uint_fast8_t		*/
+#define	PRIXFAST16	"X"	/* uint_fast16_t	*/
+#define	PRIXFAST32	"X"	/* uint_fast32_t	*/
+#define	PRIXFAST64	"llX"	/* uint_fast64_t	*/
+#define	PRIXMAX		"llX"	/* uintmax_t		*/
+#define	PRIXPTR		"lX"	/* uintptr_t		*/
+
+/* fscanf macros for signed integers */
+
+#define	SCNd8		"hhd"	/* int8_t		*/
+#define	SCNd16		"hd"	/* int16_t		*/
+#define	SCNd32		"d"	/* int32_t		*/
+#define	SCNd64		"lld"	/* int64_t		*/
+#define	SCNdLEAST8	"hhd"	/* int_least8_t		*/
+#define	SCNdLEAST16	"hd"	/* int_least16_t	*/
+#define	SCNdLEAST32	"d"	/* int_least32_t	*/
+#define	SCNdLEAST64	"lld"	/* int_least64_t	*/
+#define	SCNdFAST8	"d"	/* int_fast8_t		*/
+#define	SCNdFAST16	"d"	/* int_fast16_t		*/
+#define	SCNdFAST32	"d"	/* int_fast32_t		*/
+#define	SCNdFAST64	"lld"	/* int_fast64_t		*/
+#define	SCNdMAX		"lld"	/* intmax_t		*/
+#define	SCNdPTR		"ld"	/* intptr_t		*/
+
+#define	SCNi8		"hhi"	/* int8_t		*/
+#define	SCNi16		"hi"	/* int16_t		*/
+#define	SCNi32		"i"	/* int32_t		*/
+#define	SCNi64		"lli"	/* int64_t		*/
+#define	SCNiLEAST8	"hhi"	/* int_least8_t		*/
+#define	SCNiLEAST16	"hi"	/* int_least16_t	*/
+#define	SCNiLEAST32	"i"	/* int_least32_t	*/
+#define	SCNiLEAST64	"lli"	/* int_least64_t	*/
+#define	SCNiFAST8	"i"	/* int_fast8_t		*/
+#define	SCNiFAST16	"i"	/* int_fast16_t		*/
+#define	SCNiFAST32	"i"	/* int_fast32_t		*/
+#define	SCNiFAST64	"lli"	/* int_fast64_t		*/
+#define	SCNiMAX		"lli"	/* intmax_t		*/
+#define	SCNiPTR		"li"	/* intptr_t		*/
+
+/* fscanf macros for unsigned integers */
+
+#define	SCNo8		"hho"	/* uint8_t		*/
+#define	SCNo16		"ho"	/* uint16_t		*/
+#define	SCNo32		"o"	/* uint32_t		*/
+#define	SCNo64		"llo"	/* uint64_t		*/
+#define	SCNoLEAST8	"hho"	/* uint_least8_t	*/
+#define	SCNoLEAST16	"ho"	/* uint_least16_t	*/
+#define	SCNoLEAST32	"o"	/* uint_least32_t	*/
+#define	SCNoLEAST64	"llo"	/* uint_least64_t	*/
+#define	SCNoFAST8	"o"	/* uint_fast8_t		*/
+#define	SCNoFAST16	"o"	/* uint_fast16_t	*/
+#define	SCNoFAST32	"o"	/* uint_fast32_t	*/
+#define	SCNoFAST64	"llo"	/* uint_fast64_t	*/
+#define	SCNoMAX		"llo"	/* uintmax_t		*/
+#define	SCNoPTR		"lo"	/* uintptr_t		*/
+
+#define	SCNu8		"hhu"	/* uint8_t		*/
+#define	SCNu16		"hu"	/* uint16_t		*/
+#define	SCNu32		"u"	/* uint32_t		*/
+#define	SCNu64		"llu"	/* uint64_t		*/
+#define	SCNuLEAST8	"hhu"	/* uint_least8_t	*/
+#define	SCNuLEAST16	"hu"	/* uint_least16_t	*/
+#define	SCNuLEAST32	"u"	/* uint_least32_t	*/
+#define	SCNuLEAST64	"llu"	/* uint_least64_t	*/
+#define	SCNuFAST8	"u"	/* uint_fast8_t		*/
+#define	SCNuFAST16	"u"	/* uint_fast16_t	*/
+#define	SCNuFAST32	"u"	/* uint_fast32_t	*/
+#define	SCNuFAST64	"llu"	/* uint_fast64_t	*/
+#define	SCNuMAX		"llu"	/* uintmax_t		*/
+#define	SCNuPTR		"lu"	/* uintptr_t		*/
+
+#define	SCNx8		"hhx"	/* uint8_t		*/
+#define	SCNx16		"hx"	/* uint16_t		*/
+#define	SCNx32		"x"	/* uint32_t		*/
+#define	SCNx64		"llx"	/* uint64_t		*/
+#define	SCNxLEAST8	"hhx"	/* uint_least8_t	*/
+#define	SCNxLEAST16	"hx"	/* uint_least16_t	*/
+#define	SCNxLEAST32	"x"	/* uint_least32_t	*/
+#define	SCNxLEAST64	"llx"	/* uint_least64_t	*/
+#define	SCNxFAST8	"x"	/* uint_fast8_t		*/
+#define	SCNxFAST16	"x"	/* uint_fast16_t	*/
+#define	SCNxFAST32	"x"	/* uint_fast32_t	*/
+#define	SCNxFAST64	"llx"	/* uint_fast64_t	*/
+#define	SCNxMAX		"llx"	/* uintmax_t		*/
+#define	SCNxPTR		"lx"	/* uintptr_t		*/
+
+#endif /* !_ARM_INT_FMTIO_H_ */

--- a/StdLib/Include/Ia32/machine/int_fmtio.h
+++ b/StdLib/Include/Ia32/machine/int_fmtio.h
@@ -1,0 +1,212 @@
+/*	$NetBSD: int_fmtio.h,v 1.9 2014/07/28 11:22:46 joerg Exp $	*/
+
+/*-
+ * Copyright (c) 2001 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Klaus Klein.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _I386_INT_FMTIO_H_
+#define _I386_INT_FMTIO_H_
+
+/*
+ * 7.8.1 Macros for format specifiers
+ */
+
+/* fprintf macros for signed integers */
+
+#define	PRId8		"d"	/* int8_t		*/
+#define	PRId16		"d"	/* int16_t		*/
+#define	PRId32		"d"	/* int32_t		*/
+#define	PRId64		"lld"	/* int64_t		*/
+#define	PRIdLEAST8	"d"	/* int_least8_t		*/
+#define	PRIdLEAST16	"d"	/* int_least16_t	*/
+#define	PRIdLEAST32	"d"	/* int_least32_t	*/
+#define	PRIdLEAST64	"lld"	/* int_least64_t	*/
+#define	PRIdFAST8	"d"	/* int_fast8_t		*/
+#define	PRIdFAST16	"d"	/* int_fast16_t		*/
+#define	PRIdFAST32	"d"	/* int_fast32_t		*/
+#define	PRIdFAST64	"lld"	/* int_fast64_t		*/
+#define	PRIdMAX		"lld"	/* intmax_t		*/
+#define	PRIdPTR		"d"	/* intptr_t		*/
+
+#define	PRIi8		"i"	/* int8_t		*/
+#define	PRIi16		"i"	/* int16_t		*/
+#define	PRIi32		"i"	/* int32_t		*/
+#define	PRIi64		"lli"	/* int64_t		*/
+#define	PRIiLEAST8	"i"	/* int_least8_t		*/
+#define	PRIiLEAST16	"i"	/* int_least16_t	*/
+#define	PRIiLEAST32	"i"	/* int_least32_t	*/
+#define	PRIiLEAST64	"lli"	/* int_least64_t	*/
+#define	PRIiFAST8	"i"	/* int_fast8_t		*/
+#define	PRIiFAST16	"i"	/* int_fast16_t		*/
+#define	PRIiFAST32	"i"	/* int_fast32_t		*/
+#define	PRIiFAST64	"lli"	/* int_fast64_t		*/
+#define	PRIiMAX		"lli"	/* intmax_t		*/
+#define	PRIiPTR		"i"	/* intptr_t		*/
+
+/* fprintf macros for unsigned integers */
+
+#define	PRIo8		"o"	/* uint8_t		*/
+#define	PRIo16		"o"	/* uint16_t		*/
+#define	PRIo32		"o"	/* uint32_t		*/
+#define	PRIo64		"llo"	/* uint64_t		*/
+#define	PRIoLEAST8	"o"	/* uint_least8_t	*/
+#define	PRIoLEAST16	"o"	/* uint_least16_t	*/
+#define	PRIoLEAST32	"o"	/* uint_least32_t	*/
+#define	PRIoLEAST64	"llo"	/* uint_least64_t	*/
+#define	PRIoFAST8	"o"	/* uint_fast8_t		*/
+#define	PRIoFAST16	"o"	/* uint_fast16_t	*/
+#define	PRIoFAST32	"o"	/* uint_fast32_t	*/
+#define	PRIoFAST64	"llo"	/* uint_fast64_t	*/
+#define	PRIoMAX		"llo"	/* uintmax_t		*/
+#define	PRIoPTR		"o"	/* uintptr_t		*/
+
+#define	PRIu8		"u"	/* uint8_t		*/
+#define	PRIu16		"u"	/* uint16_t		*/
+#define	PRIu32		"u"	/* uint32_t		*/
+#define	PRIu64		"llu"	/* uint64_t		*/
+#define	PRIuLEAST8	"u"	/* uint_least8_t	*/
+#define	PRIuLEAST16	"u"	/* uint_least16_t	*/
+#define	PRIuLEAST32	"u"	/* uint_least32_t	*/
+#define	PRIuLEAST64	"llu"	/* uint_least64_t	*/
+#define	PRIuFAST8	"u"	/* uint_fast8_t		*/
+#define	PRIuFAST16	"u"	/* uint_fast16_t	*/
+#define	PRIuFAST32	"u"	/* uint_fast32_t	*/
+#define	PRIuFAST64	"llu"	/* uint_fast64_t	*/
+#define	PRIuMAX		"llu"	/* uintmax_t		*/
+#define	PRIuPTR		"u"	/* uintptr_t		*/
+
+#define	PRIx8		"x"	/* uint8_t		*/
+#define	PRIx16		"x"	/* uint16_t		*/
+#define	PRIx32		"x"	/* uint32_t		*/
+#define	PRIx64		"llx"	/* uint64_t		*/
+#define	PRIxLEAST8	"x"	/* uint_least8_t	*/
+#define	PRIxLEAST16	"x"	/* uint_least16_t	*/
+#define	PRIxLEAST32	"x"	/* uint_least32_t	*/
+#define	PRIxLEAST64	"llx"	/* uint_least64_t	*/
+#define	PRIxFAST8	"x"	/* uint_fast8_t		*/
+#define	PRIxFAST16	"x"	/* uint_fast16_t	*/
+#define	PRIxFAST32	"x"	/* uint_fast32_t	*/
+#define	PRIxFAST64	"llx"	/* uint_fast64_t	*/
+#define	PRIxMAX		"llx"	/* uintmax_t		*/
+#define	PRIxPTR		"x"	/* uintptr_t		*/
+
+#define	PRIX8		"X"	/* uint8_t		*/
+#define	PRIX16		"X"	/* uint16_t		*/
+#define	PRIX32		"X"	/* uint32_t		*/
+#define	PRIX64		"llX"	/* uint64_t		*/
+#define	PRIXLEAST8	"X"	/* uint_least8_t	*/
+#define	PRIXLEAST16	"X"	/* uint_least16_t	*/
+#define	PRIXLEAST32	"X"	/* uint_least32_t	*/
+#define	PRIXLEAST64	"llX"	/* uint_least64_t	*/
+#define	PRIXFAST8	"X"	/* uint_fast8_t		*/
+#define	PRIXFAST16	"X"	/* uint_fast16_t	*/
+#define	PRIXFAST32	"X"	/* uint_fast32_t	*/
+#define	PRIXFAST64	"llX"	/* uint_fast64_t	*/
+#define	PRIXMAX		"llX"	/* uintmax_t		*/
+#define	PRIXPTR		"X"	/* uintptr_t		*/
+
+/* fscanf macros for signed integers */
+
+#define	SCNd8		"hhd"	/* int8_t		*/
+#define	SCNd16		"hd"	/* int16_t		*/
+#define	SCNd32		"d"	/* int32_t		*/
+#define	SCNd64		"lld"	/* int64_t		*/
+#define	SCNdLEAST8	"hhd"	/* int_least8_t		*/
+#define	SCNdLEAST16	"hd"	/* int_least16_t	*/
+#define	SCNdLEAST32	"d"	/* int_least32_t	*/
+#define	SCNdLEAST64	"lld"	/* int_least64_t	*/
+#define	SCNdFAST8	"d"	/* int_fast8_t		*/
+#define	SCNdFAST16	"d"	/* int_fast16_t		*/
+#define	SCNdFAST32	"d"	/* int_fast32_t		*/
+#define	SCNdFAST64	"lld"	/* int_fast64_t		*/
+#define	SCNdMAX		"lld"	/* intmax_t		*/
+#define	SCNdPTR		"d"	/* intptr_t		*/
+
+#define	SCNi8		"hhi"	/* int8_t		*/
+#define	SCNi16		"hi"	/* int16_t		*/
+#define	SCNi32		"i"	/* int32_t		*/
+#define	SCNi64		"lli"	/* int64_t		*/
+#define	SCNiLEAST8	"hhi"	/* int_least8_t		*/
+#define	SCNiLEAST16	"hi"	/* int_least16_t	*/
+#define	SCNiLEAST32	"i"	/* int_least32_t	*/
+#define	SCNiLEAST64	"lli"	/* int_least64_t	*/
+#define	SCNiFAST8	"i"	/* int_fast8_t		*/
+#define	SCNiFAST16	"i"	/* int_fast16_t		*/
+#define	SCNiFAST32	"i"	/* int_fast32_t		*/
+#define	SCNiFAST64	"lli"	/* int_fast64_t		*/
+#define	SCNiMAX		"lli"	/* intmax_t		*/
+#define	SCNiPTR		"i"	/* intptr_t		*/
+
+/* fscanf macros for unsigned integers */
+
+#define	SCNo8		"hho"	/* uint8_t		*/
+#define	SCNo16		"ho"	/* uint16_t		*/
+#define	SCNo32		"o"	/* uint32_t		*/
+#define	SCNo64		"llo"	/* uint64_t		*/
+#define	SCNoLEAST8	"hho"	/* uint_least8_t	*/
+#define	SCNoLEAST16	"ho"	/* uint_least16_t	*/
+#define	SCNoLEAST32	"o"	/* uint_least32_t	*/
+#define	SCNoLEAST64	"llo"	/* uint_least64_t	*/
+#define	SCNoFAST8	"o"	/* uint_fast8_t		*/
+#define	SCNoFAST16	"o"	/* uint_fast16_t	*/
+#define	SCNoFAST32	"o"	/* uint_fast32_t	*/
+#define	SCNoFAST64	"llo"	/* uint_fast64_t	*/
+#define	SCNoMAX		"llo"	/* uintmax_t		*/
+#define	SCNoPTR		"o"	/* uintptr_t		*/
+
+#define	SCNu8		"hhu"	/* uint8_t		*/
+#define	SCNu16		"hu"	/* uint16_t		*/
+#define	SCNu32		"u"	/* uint32_t		*/
+#define	SCNu64		"llu"	/* uint64_t		*/
+#define	SCNuLEAST8	"hhu"	/* uint_least8_t	*/
+#define	SCNuLEAST16	"hu"	/* uint_least16_t	*/
+#define	SCNuLEAST32	"u"	/* uint_least32_t	*/
+#define	SCNuLEAST64	"llu"	/* uint_least64_t	*/
+#define	SCNuFAST8	"u"	/* uint_fast8_t		*/
+#define	SCNuFAST16	"u"	/* uint_fast16_t	*/
+#define	SCNuFAST32	"u"	/* uint_fast32_t	*/
+#define	SCNuFAST64	"llu"	/* uint_fast64_t	*/
+#define	SCNuMAX		"llu"	/* uintmax_t		*/
+#define	SCNuPTR		"u"	/* uintptr_t		*/
+
+#define	SCNx8		"hhx"	/* uint8_t		*/
+#define	SCNx16		"hx"	/* uint16_t		*/
+#define	SCNx32		"x"	/* uint32_t		*/
+#define	SCNx64		"llx"	/* uint64_t		*/
+#define	SCNxLEAST8	"hhx"	/* uint_least8_t	*/
+#define	SCNxLEAST16	"hx"	/* uint_least16_t	*/
+#define	SCNxLEAST32	"x"	/* uint_least32_t	*/
+#define	SCNxLEAST64	"llx"	/* uint_least64_t	*/
+#define	SCNxFAST8	"x"	/* uint_fast8_t		*/
+#define	SCNxFAST16	"x"	/* uint_fast16_t	*/
+#define	SCNxFAST32	"x"	/* uint_fast32_t	*/
+#define	SCNxFAST64	"llx"	/* uint_fast64_t	*/
+#define	SCNxMAX		"llx"	/* uintmax_t		*/
+#define	SCNxPTR		"x"	/* uintptr_t		*/
+
+#endif /* !_I386_INT_FMTIO_H_ */

--- a/StdLib/Include/X64/machine/int_fmtio.h
+++ b/StdLib/Include/X64/machine/int_fmtio.h
@@ -48,7 +48,7 @@
 #define	PRId8		"d"	/* int8_t		*/
 #define	PRId16		"d"	/* int16_t		*/
 #define	PRId32		"d"	/* int32_t		*/
-#define	PRId64		"ld"	/* int64_t		*/
+#define	PRId64		"lld"	/* int64_t		*//*ll* for GCC build with EDK2 */
 #define	PRIdLEAST8	"d"	/* int_least8_t		*/
 #define	PRIdLEAST16	"d"	/* int_least16_t	*/
 #define	PRIdLEAST32	"d"	/* int_least32_t	*/
@@ -56,23 +56,23 @@
 #define	PRIdFAST8	"d"	/* int_fast8_t		*/
 #define	PRIdFAST16	"d"	/* int_fast16_t		*/
 #define	PRIdFAST32	"d"	/* int_fast32_t		*/
-#define	PRIdFAST64	"ld"	/* int_fast64_t		*/
-#define	PRIdMAX		"ld"	/* intmax_t		*/
+#define	PRIdFAST64	"lld"	/* int_fast64_t		*/
+#define	PRIdMAX		"lld"	/* intmax_t		*/
 #define	PRIdPTR		"ld"	/* intptr_t		*/
 
 #define	PRIi8		"i"	/* int8_t		*/
 #define	PRIi16		"i"	/* int16_t		*/
 #define	PRIi32		"i"	/* int32_t		*/
-#define	PRIi64		"li"	/* int64_t		*/
+#define	PRIi64		"lli"	/* int64_t		*//*ll* for GCC build with EDK2 */
 #define	PRIiLEAST8	"i"	/* int_least8_t		*/
 #define	PRIiLEAST16	"i"	/* int_least16_t	*/
 #define	PRIiLEAST32	"i"	/* int_least32_t	*/
-#define	PRIiLEAST64	"li"	/* int_least64_t	*/
+#define	PRIiLEAST64	"lli"	/* int_least64_t	*/
 #define	PRIiFAST8	"i"	/* int_fast8_t		*/
 #define	PRIiFAST16	"i"	/* int_fast16_t		*/
 #define	PRIiFAST32	"i"	/* int_fast32_t		*/
-#define	PRIiFAST64	"li"	/* int_fast64_t		*/
-#define	PRIiMAX		"li"	/* intmax_t		*/
+#define	PRIiFAST64	"lli"	/* int_fast64_t		*/
+#define	PRIiMAX		"lli"	/* intmax_t		*/
 #define	PRIiPTR		"li"	/* intptr_t		*/
 
 /* fprintf macros for unsigned integers */
@@ -80,61 +80,61 @@
 #define	PRIo8		"o"	/* uint8_t		*/
 #define	PRIo16		"o"	/* uint16_t		*/
 #define	PRIo32		"o"	/* uint32_t		*/
-#define	PRIo64		"lo"	/* uint64_t		*/
+#define	PRIo64		"llo"	/* uint64_t		*//*ll* for GCC build with EDK2 */
 #define	PRIoLEAST8	"o"	/* uint_least8_t	*/
 #define	PRIoLEAST16	"o"	/* uint_least16_t	*/
 #define	PRIoLEAST32	"o"	/* uint_least32_t	*/
-#define	PRIoLEAST64	"lo"	/* uint_least64_t	*/
+#define	PRIoLEAST64	"llo"	/* uint_least64_t	*/
 #define	PRIoFAST8	"o"	/* uint_fast8_t		*/
 #define	PRIoFAST16	"o"	/* uint_fast16_t	*/
 #define	PRIoFAST32	"o"	/* uint_fast32_t	*/
-#define	PRIoFAST64	"lo"	/* uint_fast64_t	*/
-#define	PRIoMAX		"lo"	/* uintmax_t		*/
+#define	PRIoFAST64	"llo"	/* uint_fast64_t	*/
+#define	PRIoMAX		"llo"	/* uintmax_t		*/
 #define	PRIoPTR		"lo"	/* uintptr_t		*/
 
 #define	PRIu8		"u"	/* uint8_t		*/
 #define	PRIu16		"u"	/* uint16_t		*/
 #define	PRIu32		"u"	/* uint32_t		*/
-#define	PRIu64		"lu"	/* uint64_t		*/
+#define	PRIu64		"llu"	/* uint64_t		*/ /*ll* for GCC build with EDK2 */
 #define	PRIuLEAST8	"u"	/* uint_least8_t	*/
 #define	PRIuLEAST16	"u"	/* uint_least16_t	*/
 #define	PRIuLEAST32	"u"	/* uint_least32_t	*/
-#define	PRIuLEAST64	"lu"	/* uint_least64_t	*/
+#define	PRIuLEAST64	"llu"	/* uint_least64_t	*/
 #define	PRIuFAST8	"u"	/* uint_fast8_t		*/
 #define	PRIuFAST16	"u"	/* uint_fast16_t	*/
 #define	PRIuFAST32	"u"	/* uint_fast32_t	*/
-#define	PRIuFAST64	"lu"	/* uint_fast64_t	*/
-#define	PRIuMAX		"lu"	/* uintmax_t		*/
+#define	PRIuFAST64	"llu"	/* uint_fast64_t	*/
+#define	PRIuMAX		"llu"	/* uintmax_t		*/
 #define	PRIuPTR		"lu"	/* uintptr_t		*/
 
 #define	PRIx8		"x"	/* uint8_t		*/
 #define	PRIx16		"x"	/* uint16_t		*/
 #define	PRIx32		"x"	/* uint32_t		*/
-#define	PRIx64		"lx"	/* uint64_t		*/
+#define	PRIx64		"llx"	/* uint64_t		*//*ll* for GCC build with EDK2 */
 #define	PRIxLEAST8	"x"	/* uint_least8_t	*/
 #define	PRIxLEAST16	"x"	/* uint_least16_t	*/
 #define	PRIxLEAST32	"x"	/* uint_least32_t	*/
-#define	PRIxLEAST64	"lx"	/* uint_least64_t	*/
+#define	PRIxLEAST64	"llx"	/* uint_least64_t	*/
 #define	PRIxFAST8	"x"	/* uint_fast8_t		*/
 #define	PRIxFAST16	"x"	/* uint_fast16_t	*/
 #define	PRIxFAST32	"x"	/* uint_fast32_t	*/
-#define	PRIxFAST64	"lx"	/* uint_fast64_t	*/
-#define	PRIxMAX		"lx"	/* uintmax_t		*/
+#define	PRIxFAST64	"llx"	/* uint_fast64_t	*/
+#define	PRIxMAX		"llx"	/* uintmax_t		*/
 #define	PRIxPTR		"lx"	/* uintptr_t		*/
 
 #define	PRIX8		"X"	/* uint8_t		*/
 #define	PRIX16		"X"	/* uint16_t		*/
 #define	PRIX32		"X"	/* uint32_t		*/
-#define	PRIX64		"lX"	/* uint64_t		*/
+#define	PRIX64		"llX"	/* uint64_t		*//*ll* for GCC build with EDK2 */
 #define	PRIXLEAST8	"X"	/* uint_least8_t	*/
 #define	PRIXLEAST16	"X"	/* uint_least16_t	*/
 #define	PRIXLEAST32	"X"	/* uint_least32_t	*/
-#define	PRIXLEAST64	"lX"	/* uint_least64_t	*/
+#define	PRIXLEAST64	"llX"	/* uint_least64_t	*/
 #define	PRIXFAST8	"X"	/* uint_fast8_t		*/
 #define	PRIXFAST16	"X"	/* uint_fast16_t	*/
 #define	PRIXFAST32	"X"	/* uint_fast32_t	*/
-#define	PRIXFAST64	"lX"	/* uint_fast64_t	*/
-#define	PRIXMAX		"lX"	/* uintmax_t		*/
+#define	PRIXFAST64	"llX"	/* uint_fast64_t	*/
+#define	PRIXMAX		"llX"	/* uintmax_t		*/
 #define	PRIXPTR		"lX"	/* uintptr_t		*/
 
 /* fscanf macros for signed integers */
@@ -142,31 +142,31 @@
 #define	SCNd8		"hhd"	/* int8_t		*/
 #define	SCNd16		"hd"	/* int16_t		*/
 #define	SCNd32		"d"	/* int32_t		*/
-#define	SCNd64		"ld"	/* int64_t		*/
+#define	SCNd64		"lld"	/* int64_t		*//*ll* for GCC build with EDK2 */
 #define	SCNdLEAST8	"hhd"	/* int_least8_t		*/
 #define	SCNdLEAST16	"hd"	/* int_least16_t	*/
 #define	SCNdLEAST32	"d"	/* int_least32_t	*/
-#define	SCNdLEAST64	"ld"	/* int_least64_t	*/
+#define	SCNdLEAST64	"lld"	/* int_least64_t	*/
 #define	SCNdFAST8	"d"	/* int_fast8_t		*/
 #define	SCNdFAST16	"d"	/* int_fast16_t		*/
 #define	SCNdFAST32	"d"	/* int_fast32_t		*/
-#define	SCNdFAST64	"ld"	/* int_fast64_t		*/
-#define	SCNdMAX		"ld"	/* intmax_t		*/
+#define	SCNdFAST64	"lld"	/* int_fast64_t		*/
+#define	SCNdMAX		"lld"	/* intmax_t		*/
 #define	SCNdPTR		"ld"	/* intptr_t		*/
 
 #define	SCNi8		"hhi"	/* int8_t		*/
 #define	SCNi16		"hi"	/* int16_t		*/
 #define	SCNi32		"i"	/* int32_t		*/
-#define	SCNi64		"li"	/* int64_t		*/
+#define	SCNi64		"lli"	/* int64_t		*//*ll* for GCC build with EDK2 */
 #define	SCNiLEAST8	"hhi"	/* int_least8_t		*/
 #define	SCNiLEAST16	"hi"	/* int_least16_t	*/
 #define	SCNiLEAST32	"i"	/* int_least32_t	*/
-#define	SCNiLEAST64	"li"	/* int_least64_t	*/
+#define	SCNiLEAST64	"lli"	/* int_least64_t	*/
 #define	SCNiFAST8	"i"	/* int_fast8_t		*/
 #define	SCNiFAST16	"i"	/* int_fast16_t		*/
 #define	SCNiFAST32	"i"	/* int_fast32_t		*/
-#define	SCNiFAST64	"li"	/* int_fast64_t		*/
-#define	SCNiMAX		"li"	/* intmax_t		*/
+#define	SCNiFAST64	"lli"	/* int_fast64_t		*/
+#define	SCNiMAX		"lli"	/* intmax_t		*/
 #define	SCNiPTR		"li"	/* intptr_t		*/
 
 /* fscanf macros for unsigned integers */
@@ -174,46 +174,46 @@
 #define	SCNo8		"hho"	/* uint8_t		*/
 #define	SCNo16		"ho"	/* uint16_t		*/
 #define	SCNo32		"o"	/* uint32_t		*/
-#define	SCNo64		"lo"	/* uint64_t		*/
+#define	SCNo64		"llo"	/* uint64_t		*//*ll* for GCC build with EDK2 */
 #define	SCNoLEAST8	"hho"	/* uint_least8_t	*/
 #define	SCNoLEAST16	"ho"	/* uint_least16_t	*/
 #define	SCNoLEAST32	"o"	/* uint_least32_t	*/
-#define	SCNoLEAST64	"lo"	/* uint_least64_t	*/
+#define	SCNoLEAST64	"llo"	/* uint_least64_t	*/
 #define	SCNoFAST8	"o"	/* uint_fast8_t		*/
 #define	SCNoFAST16	"o"	/* uint_fast16_t	*/
 #define	SCNoFAST32	"o"	/* uint_fast32_t	*/
-#define	SCNoFAST64	"lo"	/* uint_fast64_t	*/
-#define	SCNoMAX		"lo"	/* uintmax_t		*/
+#define	SCNoFAST64	"llo"	/* uint_fast64_t	*/
+#define	SCNoMAX		"llo"	/* uintmax_t		*/
 #define	SCNoPTR		"lo"	/* uintptr_t		*/
 
 #define	SCNu8		"hhu"	/* uint8_t		*/
 #define	SCNu16		"hu"	/* uint16_t		*/
 #define	SCNu32		"u"	/* uint32_t		*/
-#define	SCNu64		"lu"	/* uint64_t		*/
+#define	SCNu64		"llu"	/* uint64_t		*//*ll* for GCC build with EDK2 */
 #define	SCNuLEAST8	"hhu"	/* uint_least8_t	*/
 #define	SCNuLEAST16	"hu"	/* uint_least16_t	*/
 #define	SCNuLEAST32	"u"	/* uint_least32_t	*/
-#define	SCNuLEAST64	"lu"	/* uint_least64_t	*/
+#define	SCNuLEAST64	"llu"	/* uint_least64_t	*/
 #define	SCNuFAST8	"u"	/* uint_fast8_t		*/
 #define	SCNuFAST16	"u"	/* uint_fast16_t	*/
 #define	SCNuFAST32	"u"	/* uint_fast32_t	*/
-#define	SCNuFAST64	"lu"	/* uint_fast64_t	*/
-#define	SCNuMAX		"lu"	/* uintmax_t		*/
+#define	SCNuFAST64	"llu"	/* uint_fast64_t	*/
+#define	SCNuMAX		"llu"	/* uintmax_t		*/
 #define	SCNuPTR		"lu"	/* uintptr_t		*/
 
 #define	SCNx8		"hhx"	/* uint8_t		*/
 #define	SCNx16		"hx"	/* uint16_t		*/
 #define	SCNx32		"x"	/* uint32_t		*/
-#define	SCNx64		"lx"	/* uint64_t		*/
+#define	SCNx64		"llx"	/* uint64_t		*/ /*ll* for GCC build with EDK2 */
 #define	SCNxLEAST8	"hhx"	/* uint_least8_t	*/
 #define	SCNxLEAST16	"hx"	/* uint_least16_t	*/
 #define	SCNxLEAST32	"x"	/* uint_least32_t	*/
-#define	SCNxLEAST64	"lx"	/* uint_least64_t	*/
+#define	SCNxLEAST64	"llx"	/* uint_least64_t	*/
 #define	SCNxFAST8	"x"	/* uint_fast8_t		*/
 #define	SCNxFAST16	"x"	/* uint_fast16_t	*/
 #define	SCNxFAST32	"x"	/* uint_fast32_t	*/
-#define	SCNxFAST64	"lx"	/* uint_fast64_t	*/
-#define	SCNxMAX		"lx"	/* uintmax_t		*/
+#define	SCNxFAST64	"llx"	/* uint_fast64_t	*/
+#define	SCNxMAX		"llx"	/* uintmax_t		*/
 #define	SCNxPTR		"lx"	/* uintptr_t		*/
 
 #endif /* !_AMD64_INT_FMTIO_H_ */

--- a/StdLib/Include/getopt.h
+++ b/StdLib/Include/getopt.h
@@ -1,0 +1,76 @@
+/*	$OpenBSD: getopt.h,v 1.3 2013/11/22 21:32:49 millert Exp $	*/
+/*	$NetBSD: getopt.h,v 1.4 2000/07/07 10:43:54 ad Exp $	*/
+
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _GETOPT_H_
+#define _GETOPT_H_
+
+#include <sys/cdefs.h>
+
+/*
+ * GNU-like getopt_long()
+ */
+#define no_argument        0
+#define required_argument  1
+#define optional_argument  2
+
+struct option {
+	/* name of long option */
+	const char *name;
+	/*
+	 * one of no_argument, required_argument, and optional_argument:
+	 * whether option takes an argument
+	 */
+	int has_arg;
+	/* if not NULL, set *flag to val when option found */
+	int *flag;
+	/* if flag not NULL, value to set *flag to; else return value */
+	int val;
+};
+
+__BEGIN_DECLS
+int	 getopt_long(int, char * const *, const char *,
+	    const struct option *, int *);
+int	 getopt_long_only(int, char * const *, const char *,
+	    const struct option *, int *);
+#ifndef _GETOPT_DEFINED_
+#define _GETOPT_DEFINED_
+int	 getopt(int, char * const *, const char *);
+
+extern   char *optarg;                  /* getopt(3) external variables */
+extern   int opterr;
+extern   int optind;
+extern   int optopt;
+extern   int optreset;
+#endif
+__END_DECLS
+ 
+#endif /* !_GETOPT_H_ */

--- a/StdLib/Include/inttypes.h
+++ b/StdLib/Include/inttypes.h
@@ -39,7 +39,7 @@
 #define _INTTYPES_H_
 
 #include  <sys/EfiCdefs.h>
-//#include  <sys/inttypes.h>
+#include  <sys/inttypes.h>
 #include  <sys/stdint.h>
 #include  <machine/ansi.h>
 

--- a/StdLib/Include/sys/socket.h
+++ b/StdLib/Include/sys/socket.h
@@ -82,6 +82,12 @@ typedef __sa_family_t sa_family_t;
 #ifndef socklen_t
 typedef __socklen_t socklen_t;
 #define socklen_t __socklen_t
+/*add some defines that some applications may look for to check for socklen_t type*/
+#define _SOCKLEN_T_DEFINED_
+#define _SOCKLEN_T_DECLARED
+#define __socklen_t_defined
+#define _SOCKLEN_T
+#define __DEFINED_socklen_t
 #endif
 
 #include <machine/ansi.h>

--- a/StdLib/Include/unistd.h
+++ b/StdLib/Include/unistd.h
@@ -37,9 +37,7 @@ int             dup(int);
 int             rename(const char *, const char *);
 
 /* Functions implemented for compatibility. */
-int             getopt(int, char * const [], const char *);
-extern   char  *optarg;     /* getopt(3) external variables */
-extern   int    optind;
+#include  <getopt.h>
 pid_t           getpgrp(void);
 pid_t           tcgetpgrp(int);
 char           *getpass(const char *);
@@ -156,9 +154,6 @@ long            sysconf(int);
 int             tcsetpgrp(int, pid_t);
 __aconst char  *ttyname(int);
 
-extern   int    opterr;
-extern   int    optopt;
-extern   int    optreset;
 extern   char  *suboptarg;
 
 int             setegid(gid_t);

--- a/StdLib/LibC/LibC.inf
+++ b/StdLib/LibC/LibC.inf
@@ -106,6 +106,7 @@
   LibStdLib
   LibStdio
   LibString
+  LibErr
   DevConsole
 
 ################################################################

--- a/StdLib/LibC/Uefi/Uefi.inf
+++ b/StdLib/LibC/Uefi/Uefi.inf
@@ -31,6 +31,7 @@
   Xform.c
   compat.c
   StubFunctions.c
+  getopt_long.c
 
 [Packages]
   StdLib/StdLib.dec

--- a/StdLib/LibC/Uefi/compat.c
+++ b/StdLib/LibC/Uefi/compat.c
@@ -97,45 +97,7 @@
 #include  <sys/syslimits.h>
 
 #ifndef HAVE_GETOPT
-char *optarg;
-int optind = 1;
-int
-getopt(int argc, char **argv, char *args)
-{
-        size_t n;
-  size_t nlen = strlen(args);
-        char cmd;
-        char rv;
-
-        if (argv[optind] && *argv[optind] == '-') {
-                cmd = *(argv[optind] + 1);
-
-                for (n = 0; n < nlen; n++) {
-                        if (args[n] == ':')
-        continue;
-                        if (args[n] == cmd) {
-                                rv = *(argv[optind] + 1);
-                                if (args[n+1] == ':') {
-          if (*(argv[optind] + 2) != '\0') {
-                                          optarg = argv[optind] + 2;
-            optind += 1;
-          } else {
-                                          optarg = argv[optind + 1];
-                                          optind += 2;
-          }
-                                        if (!optarg)
-             optarg="";
-                                        return rv;
-                                } else {
-                                        optarg = NULL;
-                                        optind += 1;
-                                        return rv;
-                                }
-                        }
-                }
-        }
-        return -1;
-}
+#include  <getopt.h> //functionality for getopt and getopt_long provided in getopt_long.c
 #endif
 
 #define ISPATHSEPARATOR(x) ((x == '/') || (x == '\\'))

--- a/StdLib/LibC/Uefi/getopt_long.c
+++ b/StdLib/LibC/Uefi/getopt_long.c
@@ -1,0 +1,524 @@
+/*	$OpenBSD: getopt_long.c,v 1.28 2015/09/19 04:02:21 guenther Exp $	*/
+/*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
+
+/*
+ * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Sponsored in part by the Defense Advanced Research Projects
+ * Agency (DARPA) and Air Force Research Laboratory, Air Force
+ * Materiel Command, USAF, under agreement number F39502-99-1-0512.
+ */
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <err.h> /*warnx*/
+#include <errno.h>
+#include <getopt.h>
+#include <stdlib.h>
+#include <string.h>
+
+int	opterr = 1;		/* if error message should be printed */
+int	optind = 1;		/* index into parent argv vector */
+int	optopt = '?';		/* character checked for validity */
+int	optreset;		/* reset getopt */
+char    *optarg;		/* argument associated with option */
+
+#if 0
+/* DEF_* only work on initialized (non-COMMON) variables */
+DEF_WEAK(opterr);
+DEF_WEAK(optind);
+DEF_WEAK(optopt);
+#endif
+
+#define PRINT_ERROR	((opterr) && (*options != ':'))
+
+#define FLAG_PERMUTE	0x01	/* permute non-options to the end of argv */
+#define FLAG_ALLARGS	0x02	/* treat non-options as args to option "-1" */
+#define FLAG_LONGONLY	0x04	/* operate as getopt_long_only */
+
+/* return values */
+#define	BADCH		(int)'?'
+#define	BADARG		((*options == ':') ? (int)':' : (int)'?')
+#define	INORDER 	(int)1
+
+#define	EMSG		""
+
+static int getopt_internal(int, char * const *, const char *,
+			   const struct option *, int *, int);
+static int parse_long_options(char * const *, const char *,
+			      const struct option *, int *, int, int);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+
+	return (b);
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(int panonopt_start, int panonopt_end, int opt_end,
+	char * const *nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end+i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			((char **)nargv)[pos] = nargv[cstart];
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+/*
+ * parse_long_options --
+ *	Parse long options in argc/argv argument vector.
+ * Returns -1 if short_too is set and the option does not match long_options.
+ */
+static int
+parse_long_options(char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int short_too, int flags)
+{
+	char *current_argv, *has_equal;
+	size_t current_argv_len;
+	int i, match, exact_match, second_partial_match;
+
+	current_argv = place;
+	match = -1;
+	exact_match = 0;
+	second_partial_match = 0;
+
+	optind++;
+
+	if ((has_equal = strchr(current_argv, '=')) != NULL) {
+		/* argument found (--option=arg) */
+		current_argv_len = has_equal - current_argv;
+		has_equal++;
+	} else
+		current_argv_len = strlen(current_argv);
+
+	for (i = 0; long_options[i].name; i++) {
+		/* find matching long option */
+		if (strncmp(current_argv, long_options[i].name,
+		    current_argv_len))
+			continue;
+
+		if (strlen(long_options[i].name) == current_argv_len) {
+			/* exact match */
+			match = i;
+			exact_match = 1;
+			break;
+		}
+		/*
+		 * If this is a known short option, don't allow
+		 * a partial match of a single character.
+		 */
+		if (short_too && current_argv_len == 1)
+			continue;
+
+		if (match == -1)	/* first partial match */
+			match = i;
+		else if ((flags & FLAG_LONGONLY) ||
+		    long_options[i].has_arg != long_options[match].has_arg ||
+		    long_options[i].flag != long_options[match].flag ||
+		    long_options[i].val != long_options[match].val)
+			second_partial_match = 1;
+	}
+	if (!exact_match && second_partial_match) {
+		/* ambiguous abbreviation */
+		if (PRINT_ERROR)
+			warnx(ambig, (int)current_argv_len, current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (match != -1) {		/* option found */
+		if (long_options[match].has_arg == no_argument
+		    && has_equal) {
+			if (PRINT_ERROR)
+				warnx(noarg, (int)current_argv_len,
+				     current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			return (BADARG);
+		}
+		if (long_options[match].has_arg == required_argument ||
+		    long_options[match].has_arg == optional_argument) {
+			if (has_equal)
+				optarg = has_equal;
+			else if (long_options[match].has_arg ==
+			    required_argument) {
+				/*
+				 * optional argument doesn't use next nargv
+				 */
+				optarg = nargv[optind++];
+			}
+		}
+		if ((long_options[match].has_arg == required_argument)
+		    && (optarg == NULL)) {
+			/*
+			 * Missing argument; leading ':' indicates no error
+			 * should be generated.
+			 */
+			if (PRINT_ERROR)
+				warnx(recargstring,
+				    current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			--optind;
+			return (BADARG);
+		}
+	} else {			/* unknown option */
+		if (short_too) {
+			--optind;
+			return (-1);
+		}
+		if (PRINT_ERROR)
+			warnx(illoptstring, current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (idx)
+		*idx = match;
+	if (long_options[match].flag) {
+		*long_options[match].flag = long_options[match].val;
+		return (0);
+	} else
+		return (long_options[match].val);
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ */
+static int
+getopt_internal(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int flags)
+{
+	char *oli;				/* option letter list index */
+	int optchar, short_too;
+	static int posixly_correct = -1;
+
+	if (options == NULL)
+		return (-1);
+
+	/*
+	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
+	 * XXX using optreset.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = optreset = 1;
+
+	/*
+	 * Disable GNU extensions if POSIXLY_CORRECT is set or options
+	 * string begins with a '+'.
+	 */
+	if (posixly_correct == -1 || optreset)
+		posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
+	if (*options == '-')
+		flags |= FLAG_ALLARGS;
+	else if (posixly_correct || *options == '+')
+		flags &= ~FLAG_PERMUTE;
+	if (*options == '+' || *options == '-')
+		options++;
+
+	optarg = NULL;
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+		if (*(place = nargv[optind]) != '-' ||
+		    (place[1] == '\0' && strchr(options, '-') == NULL)) {
+			place = EMSG;		/* found non-option */
+			if (flags & FLAG_ALLARGS) {
+				/*
+				 * GNU extension:
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return (INORDER);
+			}
+			if (!(flags & FLAG_PERMUTE)) {
+				/*
+				 * If no permutation wanted, stop parsing
+				 * at first non-option.
+				 */
+				return (-1);
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				nonopt_start = optind -
+				    (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+
+		/*
+		 * If we have "-" do nothing, if "--" we are done.
+		 */
+		if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+			optind++;
+			place = EMSG;
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+	}
+
+	/*
+	 * Check long options if:
+	 *  1) we were passed some
+	 *  2) the arg is not just "-"
+	 *  3) either the arg starts with -- we are getopt_long_only()
+	 */
+	if (long_options != NULL && place != nargv[optind] &&
+	    (*place == '-' || (flags & FLAG_LONGONLY))) {
+		short_too = 0;
+		if (*place == '-')
+			place++;		/* --foo long option */
+		else if (*place != ':' && strchr(options, *place) != NULL)
+			short_too = 1;		/* could be short option too */
+
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, short_too, flags);
+		if (optchar != -1) {
+			place = EMSG;
+			return (optchar);
+		}
+	}
+
+	if ((optchar = (int)*place++) == (int)':' ||
+	    (optchar == (int)'-' && *place != '\0') ||
+	    (oli = strchr(options, optchar)) == NULL) {
+		/*
+		 * If the user specified "-" and  '-' isn't listed in
+		 * options, return -1 (non-option) as per POSIX.
+		 * Otherwise, it is an unknown option character (or ':').
+		 */
+		if (optchar == (int)'-' && *place == '\0')
+			return (-1);
+		if (!*place)
+			++optind;
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+		optopt = optchar;
+		return (BADCH);
+	}
+	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+		/* -W long-option */
+		if (*place)			/* no space */
+			/* NOTHING */;
+		else if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+			optopt = optchar;
+			return (BADARG);
+		} else				/* white space */
+			place = nargv[optind];
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, 0, flags);
+		place = EMSG;
+		return (optchar);
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = place;
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+				optopt = optchar;
+				return (BADARG);
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return (optchar);
+}
+
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the BSD getopt]
+ */
+int
+getopt(int nargc, char * const *nargv, const char *options)
+{
+
+	/*
+	 * We don't pass FLAG_PERMUTE to getopt_internal() since
+	 * the BSD getopt(3) (unlike GNU) has never done this.
+	 *
+	 * Furthermore, since many privileged programs call getopt()
+	 * before dropping privileges it makes sense to keep things
+	 * as simple (and bug-free) as possible.
+	 */
+	return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
+}
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE));
+}
+
+/*
+ * getopt_long_only --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long_only(int nargc, char * const *nargv, const char *options,
+    const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE|FLAG_LONGONLY));
+}
+


### PR DESCRIPTION
I made a few changes to edk2 stdlib to build an application for the UEFI shell.

- Added format macros for int types to Aarch64, ARM, and Ia32. Also modified the X64 macros so that everything would build when they are used.
- Added some macros that can be used for compatibility that define when socklen_t has been defined.
- Added getopt_long parser from OpenBSD to provide long and short option parsing capability with getopt.