### PR TITLE
Fix missing __nanf constant

### DIFF
--- a/StdLib/LibC/LibC.inf
+++ b/StdLib/LibC/LibC.inf
@@ -34,6 +34,7 @@
   Main/isnand_ieee754.c
   Main/isnanf_ieee754.c
   Main/infinityf_ieee754.c
+  Main/nanf_ieee754.c
   Main/Main.c
   Main/HtoNtoH.c
   Main/ByteSwap.c

--- a/StdLib/LibC/Main/nanf_ieee754.c
+++ b/StdLib/LibC/Main/nanf_ieee754.c
@@ -1,0 +1,15 @@
+/*
+ * IEEE-compatible nanf.c -- public domain.
+ */
+#include  <LibConfig.h>
+#include <sys/EfiCdefs.h>
+
+#include <math.h>
+#include <machine/endian.h>
+
+const union __float_u __nanf =
+#if BYTE_ORDER == BIG_ENDIAN
+  { { 0x7f, 0xc0,     0,    0 } };
+#else
+  { {    0,    0,  0xc0, 0x7f } };
+#endif


### PR DESCRIPTION
File StdLib/Include/math.h:406 defines NAN constant as  __nanf.__val. 
The problem is that __nanf is never defined.

Fix is simple: define __nanf in similar way as __infinityf

Signed-off-by: Kloper Dimitry <dimitry.kloper@intel.com>