### PR TITLE
Fix realpath() signature to match standard

### DIFF
--- a/StdLib/Include/stdlib.h
+++ b/StdLib/Include/stdlib.h
@@ -74,7 +74,7 @@
                            const wchar_t * __restrict src, size_t limit);
 
     ################  Miscelaneous functions for *nix compatibility
-    char       *realpath    (char *file_name, char *resolved_name);
+    char       *realpath    (const char *file_name, char *resolved_name);
     const char *getprogname (void);
     void        setprogname (const char *progname);
 
@@ -875,7 +875,7 @@ size_t  wcstombs(char * __restrict Dest, const wchar_t * __restrict Src, size_t 
     @retval NULL                    An error occured.
     @retval resolved_name.
 **/
-char * realpath(char *file_name, char *resolved_name);
+char * realpath(const char *file_name, char *resolved_name);
 
 /** The getprogname() function returns the name of the program.  If the name
     has not been set yet, it will return NULL.

--- a/StdLib/LibC/StdLib/realpath.c
+++ b/StdLib/LibC/StdLib/realpath.c
@@ -34,7 +34,7 @@
 **/
 char *
 realpath(
-  char *file_name,
+  const char *file_name,
   char *resolved_name
   )
 {


### PR DESCRIPTION
According to
https://pubs.opengroup.org/onlinepubs/009695399/functions/realpath.html the proposed signature of realpath() shall be

char *realpath(const char *restrict file_name,
               char *restrict resolved_name);

While "StdLib/Include/stdlib.h" provides the following:

 char *realpath    (char *file_name, char *resolved_name);

While the 'restrict' keyword is optional and may be not supported by older compilers, the 'const' part for the first argument is critical, especially when edk2 default policy to turn warnings into errors.

Note that this fix does not require actual code change, just fix in function declaration.

Signed-off-by: Kloper Dimitry <dimitry.kloper@intel.com>