### PR TITLE
Add SO_ERROR support for getsockoption()

### DIFF
--- a/StdLib/EfiSocketLib/Socket.c
+++ b/StdLib/EfiSocketLib/Socket.c
@@ -2892,6 +2892,13 @@ EslSocketOptionGet (
         pOptionData = (CONST UINT8 *)&pSocket->Type;
         LengthInBytes = sizeof ( pSocket->Type );
         break;
+      case SO_ERROR:
+        //
+        //  Return the socket type
+        //
+        pOptionData = (CONST UINT8 *)&pSocket->errno;
+        LengthInBytes = sizeof ( pSocket->errno );
+        break;
       }
       break;
     }


### PR DESCRIPTION
The errno information is private data inside socket data structure. For some reason SO_ERROR for getsockoption() is not implemented.

This ifunctionality is important for code handing O_NONBLOCK sockets.