### PR TITLE
Avoid duplicate symbols in edk2 and edk2-libc

### DIFF
--- a/StdLib/StdLib.inc
+++ b/StdLib/StdLib.inc
@@ -65,16 +65,10 @@
 
   LuaLib|AppPkg/Applications/Lua/LuaLib.inf           # Lua language library
 
-[LibraryClasses.ARM]
+[LibraryClasses.ARM, LibraryClasses.AArch64]
+!if "MSFT" not in $(FAMILY)
   NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
-  NULL|StdLib/LibC/Softfloat/Softfloat.inf
-
-  # Add support for GCC stack protector
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
-
-[LibraryClasses.AArch64]
-  NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
-
+!endif
   # Use the softfloat library to cover missing hardfloat operations.
   NULL|StdLib/LibC/Softfloat/Softfloat.inf
 


### PR DESCRIPTION
Fixes this build error when building with MSVC for aarch64:
```
CompilerIntrinsicsLib.lib(memmove_ms.obj) : error LNK2005: memmove already defined in LibString.lib(Copying.obj)
CompilerIntrinsicsLib.lib(memcmp_ms.obj) : error LNK2005: memcmp already defined in LibString.lib(Comparison.obj)
CompilerIntrinsicsLib.lib(memset_ms.obj) : error LNK2005: memset already defined in LibString.lib(Misc.obj)
CompilerIntrinsicsLib.lib(memcpy_ms.obj) : error LNK2005: memcpy already defined in LibString.lib(Copying.obj)
```

Similar approach is used in edk2/NetworkPkg/Test/NetworkPkgHostTest.dsc

Signed-off-by: Sergey Sudnitsyn <kotbegemoth@gmail.com>