### PR TITLE
Build SoftFloat with MSVC

### DIFF
--- a/StdLib/LibC/Softfloat/Softfloat.inf
+++ b/StdLib/LibC/Softfloat/Softfloat.inf
@@ -72,3 +72,4 @@
 
 [BuildOptions]
   GCC:*_*_*_CC_FLAGS  = -DSOFTFLOAT_FOR_GCC -Wno-enum-compare -fno-tree-vrp -fno-lto
+  MSFT:*_*_*_CC_FLAGS  = -DSOFTFLOAT_FOR_GCC


### PR DESCRIPTION
Fixes these errors:
```
LibSoftfloat.lib(netf2.obj) : error LNK2001: unresolved external symbol _softfloat_float128_eq
LibSoftfloat.lib(lttf2.obj) : error LNK2001: unresolved external symbol _softfloat_float128_lt
LibSoftfloat.lib(letf2.obj) : error LNK2001: unresolved external symbol _softfloat_float128_le
```

Signed-off-by: Sergey Sudnitsyn <kotbegemoth@gmail.com>