### PR TITLE
StdLib/ARM: Fix compilation dependencies

### DIFF
--- a/StdLib/StdLib.inc
+++ b/StdLib/StdLib.inc
@@ -67,13 +67,13 @@
 
 [LibraryClasses.ARM, LibraryClasses.AArch64]
 !if "MSFT" not in $(FAMILY)
-  NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+  NULL|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 !endif
   # Use the softfloat library to cover missing hardfloat operations.
   NULL|StdLib/LibC/Softfloat/Softfloat.inf
 
   # Add support for GCC stack protector
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+  NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
 
 [Components]
 # BaseLib and BaseMemoryLib need to be built with the /GL- switch when using the Microsoft


### PR DESCRIPTION
Synchronize the latest edk2_stable202411 version:
CompilerIntrinsicsLib related commit: 8f74b95a21cf106fa4eb4932e22b404c57297ba2 
BaseStackCheckLib related commit: a9b38305b64ef5997d0ba5f7d2797a75edd1f9ef