### PR TITLE
Fix for GitHub Actions failing for GCC build tools

### DIFF
--- a/.github/workflows/build-python-uefi-gcc.yaml
+++ b/.github/workflows/build-python-uefi-gcc.yaml
@@ -10,7 +10,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
GitHub Actions failing for GCC build tools

Ref: https://github.com/tianocore/edk2-libc/issues/22

GitHub actions for the GCC build is failing with an error saying
'python3-distutils has no installation candidate'.
This package is not available in the ubuntu package version 24.04.
The action has been set to runs on ubuntu-latest which was using 22.04
version earlier has switched to use 24.04 version since last 2 days.
So to fix the issue updated the runs on parameter in .yaml file
to use 22.04 version of ubuntu.

Signed-off-by: Jayaprakash N <n.jayaprakash@intel.com>