### PR TITLE
StdLib: Fix compilation dependencies

### DIFF
--- a/StdLib/StdLib.inc
+++ b/StdLib/StdLib.inc
@@ -73,7 +73,7 @@
   NULL|StdLib/LibC/Softfloat/Softfloat.inf
 
   # Add support for GCC stack protector
-  NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
+  NULL|MdePkg/Library/StackCheckLib/StackCheckLib.inf
 
 [Components]
 # BaseLib and BaseMemoryLib need to be built with the /GL- switch when using the Microsoft


### PR DESCRIPTION
Synchronize the latest edk2 version:
Move StackCheckLibStaticInit to StackCheckLib related commit: efbf5ed08c48478b51bb6b6da5670b1312755854

Closes #80

Reported-by: Jayaprakash Nevara <n.jayaprakash@intel.com>
Signed-off-by: Dongyan Qian <qiandongyan@loongson.cn>