### PR TITLE
edk2-libc/Readme.md: Update to remove reference to bugzilla

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ package are listed in [Maintainers.txt](Maintainers.txt).
 * [EDK II](https://github.com/tianocore/tianocore.github.io/wiki/EDK-II)
 * [Getting Started with EDK II](https://github.com/tianocore/tianocore.github.io/wiki/Getting-Started-with-EDK-II)
 * [Mailing Lists](https://github.com/tianocore/tianocore.github.io/wiki/Mailing-Lists)
-* [TianoCore Bugzilla](https://bugzilla.tianocore.org)
+* [edk2-libc Issues](https://github.com/tianocore/edk2-libc/issues)
 * [How To Contribute](https://github.com/tianocore/tianocore.github.io/wiki/How-To-Contribute)
 * [Release Planning](https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Release-Planning)
 * [UDK2017](https://github.com/tianocore/edk2/releases/tag/vUDK2017)


### PR DESCRIPTION

REF: https://github.com/tianocore/edk2-libc/issues/79

The reference to bugzilla in the edk2-libc repo's Readme.md is no longer
valid as the issue management has been migrated to GitHub issues.
Hence the same has been replaced with the github issues reference.

Closes https://github.com/tianocore/edk2-libc/issues/79

Signed-off-by: Jayaprakash N <n.jayaprakash@intel.com>