### PR TITLE
Remove unused variables (fixes Clang build)

### DIFF
--- a/AppPkg/Applications/Sockets/TftpServer/TftpServer.h
+++ b/AppPkg/Applications/Sockets/TftpServer/TftpServer.h
@@ -49,10 +49,10 @@
 #else   //  _MSC_VER
 #define DBG_ENTER()
 #define DBG_EXIT()
-#define DBG_EXIT_DEC(Status)
-#define DBG_EXIT_HEX(Status)
-#define DBG_EXIT_STATUS(Status)
-#define DBG_EXIT_TF(Status)
+#define DBG_EXIT_DEC(Status)    (void)Status /* suppress warning about unused variable */
+#define DBG_EXIT_HEX(Status)    (void)Status /* suppress warning about unused variable */
+#define DBG_EXIT_STATUS(Status) (void)Status /* suppress warning about unused variable */
+#define DBG_EXIT_TF(Status)     (void)Status /* suppress warning about unused variable */
 #endif  //  _MSC_VER
 
 #define DIM(x)    ( sizeof ( x ) / sizeof ( x[0] ))   ///<  Compute the number of entries in an array

--- a/StdLib/Include/Efi/EfiSocketLib.h
+++ b/StdLib/Include/Efi/EfiSocketLib.h
@@ -56,10 +56,10 @@
 #else   //  _MSC_VER
 #define DBG_ENTER()               ///<  Display routine entry
 #define DBG_EXIT()                ///<  Display routine exit
-#define DBG_EXIT_DEC(Status)      ///<  Display routine exit with decimal value
-#define DBG_EXIT_HEX(Status)      ///<  Display routine exit with hex value
-#define DBG_EXIT_STATUS(Status)   ///<  Display routine exit with status value
-#define DBG_EXIT_TF(Status)       ///<  Display routine with TRUE/FALSE value
+#define DBG_EXIT_DEC(Status)      (void)Status /* suppress warning about unused variable */
+#define DBG_EXIT_HEX(Status)      (void)Status /* suppress warning about unused variable */
+#define DBG_EXIT_STATUS(Status)   (void)Status /* suppress warning about unused variable */
+#define DBG_EXIT_TF(Status)       (void)Status /* suppress warning about unused variable */
 #endif  //  _MSC_VER
 
 #define DIM(x)    ( sizeof ( x ) / sizeof ( x[0] ))   ///<  Compute the number of entries in an array

--- a/StdLib/LibC/Uefi/Devices/UefiShell/daShell.c
+++ b/StdLib/LibC/Uefi/Devices/UefiShell/daShell.c
@@ -402,7 +402,6 @@ da_ShellIoctl(
     if( cmd == (ULONGN)FIOSETIME) {
       struct timeval  *TV;
       EFI_TIME        *ET;
-      int              mod = 0;
 
       TV = va_arg(argp, struct timeval*);
       if(TV[0].tv_sec != 0) {
@@ -411,7 +410,6 @@ da_ShellIoctl(
           (void) memcpy(&FileInfo->LastAccessTime, ET, sizeof(EFI_TIME));
           FileInfo->LastAccessTime.Nanosecond = TV[0].tv_usec * 1000;
           free(ET);
-          ++mod;
         }
       }
       if(TV[1].tv_sec != 0) {
@@ -420,7 +418,6 @@ da_ShellIoctl(
           (void) memcpy(&FileInfo->ModificationTime, ET, sizeof(EFI_TIME));
           FileInfo->ModificationTime.Nanosecond = TV[1].tv_usec * 1000;
           free(ET);
-          ++mod;
         }
       }
       /* Set access and modification times */

--- a/StdLib/LibC/Uefi/InteractiveIO/NonCanonRead.c
+++ b/StdLib/LibC/Uefi/InteractiveIO/NonCanonRead.c
@@ -36,18 +36,20 @@ IIO_NonCanonRead (
 {
   cIIO           *This;
   cFIFO          *InBuf;
-  struct termios *Termio;
+  //struct termios *Termio;
   ssize_t         NumRead;
-  cc_t            tioMin;
-  cc_t            tioTime;
-  UINT32          InputType;
+  //cc_t            tioMin;
+  //cc_t            tioTime;
+  //UINT32          InputType;
   wchar_t         InChar;     // Intermediate character buffer
 
   NumRead = -1;
   InChar  = 0;      // Initialize so compilers don't complain.
+
   This    = filp->devdata;
-  Termio  = &This->Termio;
+  //Termio  = &This->Termio;
   InBuf   = This->InBuf;
+#if 0
   tioMin  = Termio->c_cc[VMIN];
   tioTime = Termio->c_cc[VTIME];
 
@@ -69,6 +71,7 @@ IIO_NonCanonRead (
   if(tioMin   != 0)     InputType = 2;
   if(tioTime  != 0)   ++InputType;
   //switch(InputType) {
+#endif
   //  case 0:
       if(InBuf->IsEmpty(InBuf)) {
         NumRead = filp->f_ops->fo_read(filp, &filp->f_offset, sizeof(wchar_t), &InChar);


### PR DESCRIPTION
Currently when building StdLib with Clang then it fails with:
```
"clang" -MMD -MF Build/StdLib/RELEASE_CLANGPDB/X64/edk2-libc/StdLib/LibC/Wchar/Wchar/OUTPUT/Comparison.obj.deps -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -fstack-protector -ffunction-sections -fdata-sections -DSTRING_ARRAY_NAME=LibWcharStrings -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-varargs -Wno-unknown-warning-option -Wno-unaligned-access -Wno-microsoft-enum-forward-reference -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -fno-omit-frame-pointer -D __GNUC__=4 -D __GNUC_MINOR__=2 -D __GNUC_PATCHLEVEL__=1 -D __MINGW32__=1 -m64 "-DEFIAPI=__attribute__((ms_abi))" -mno-red-zone -mcmodel=small -Oz -flto -target x86_64-uefi -fno-unwind-tables -Wno-unused-command-line-argument -c -o Build/StdLib/RELEASE_CLANGPDB/X64/edk2-libc/StdLib/LibC/Wchar/Wchar/OUTPUT/./Comparison.obj -Iedk2-libc/StdLib/LibC/Wchar -IBuild/StdLib/RELEASE_CLANGPDB/X64/edk2-libc/StdLib/LibC/Wchar/Wchar/DEBUG -Iedk2-libc/StdLib -Iedk2-libc/StdLib/Include -Iedk2-libc/StdLib/Include/X64 -Iedk2-libc/StdLibPrivateInternalFiles -Iedk2-libc/StdLibPrivateInternalFiles/Include -Iedk2-libc/StdLibPrivateInternalFiles/Include/X64 -IMdePkg -IMdePkg/Include -IMdePkg/Test/UnitTest/Include -IMdePkg/Test/Mock/Include -IMdePkg/Library/MipiSysTLib/mipisyst/library/include -IMdePkg/Include/X64 edk2-libc/StdLib/LibC/Wchar/Comparison.c
edk2-libc/StdLib/LibC/Uefi/Devices/UefiShell/daShell.c:405:24: error: variable 'mod' set but not used [-Werror,-Wunused-but-set-variable]
  405 |       int              mod = 0;
      |                        ^
[...]
edk2-libc/StdLib/EfiSocketLib/Socket.c:3987:14: error: variable 'Status' set but not used [-Werror,-Wunused-but-set-variable]
 3987 |   EFI_STATUS Status;
      |              ^
[...]
edk2-libc/StdLib/LibC/Uefi/InteractiveIO/NonCanonRead.c:43:19: error: variable 'InputType' set but not used [-Werror,-Wunused-but-set-variable]
   43 |   UINT32          InputType;
      |                   ^
```

This happens because `-Wall -Werror` is enabled and for Clang that also includes `-Wunused-but-set-variable`.
This PR fixes this issue by removing unused `mod` variable and marking others as used to remove this warning.