### PR TITLE
Fix `__STDC_VERSION__` redefinition for Clang

### DIFF
--- a/StdLib/Include/sys/EfiCdefs.h
+++ b/StdLib/Include/sys/EfiCdefs.h
@@ -333,7 +333,9 @@
   #pragma warning ( disable : 4306 )
 
   #define __STDC__            1
+  #ifndef __STDC_VERSION__
   #define __STDC_VERSION__    199409L
+  #endif
   #ifndef __STDC_HOSTED__
   #define __STDC_HOSTED__     1
   #endif


### PR DESCRIPTION
Currently on Linux when using Clang when building StdLib then it fails with:

```
"clang" -MMD -MF Build/StdLib/RELEASE_CLANGPDB/X64/edk2-libc/StdLib/EfiSocketLib/EfiSocketLib/OUTPUT/DxeSupport.obj.deps -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -fstack-protector -ffunction-sections -fdata-sections -DSTRING_ARRAY_NAME=EfiSocketLibStrings -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-varargs -Wno-unknown-warning-option -Wno-unaligned-access -Wno-microsoft-enum-forward-reference -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -fno-omit-frame-pointer -D __GNUC__=4 -D __GNUC_MINOR__=2 -D __GNUC_PATCHLEVEL__=1 -D __MINGW32__=1 -m64 "-DEFIAPI=__attribute__((ms_abi))" -mno-red-zone -mcmodel=small -Oz -flto -target x86_64-pc-windows-msvc -fno-unwind-tables -Wno-unused-command-line-argument -c -o Build/StdLib/RELEASE_CLANGPDB/X64/edk2-libc/StdLib/EfiSocketLib/EfiSocketLib/OUTPUT/./DxeSupport.obj -Iedk2-libc/StdLib/EfiSocketLib -IBuild/StdLib/RELEASE_CLANGPDB/X64/edk2-libc/StdLib/EfiSocketLib/EfiSocketLib/DEBUG -IMdePkg -IMdePkg/Include -IMdePkg/Test/UnitTest/Include -IMdePkg/Test/Mock/Include -IMdePkg/Library/MipiSysTLib/mipisyst/library/include -IMdePkg/Include/X64 -IMdeModulePkg -IMdeModulePkg/Test/Mock/Include -IMdeModulePkg/Include -Iedk2-libc/StdLib -Iedk2-libc/StdLib/Include -Iedk2-libc/StdLib/Include/X64 edk2-libc/StdLib/EfiSocketLib/DxeSupport.c
In file included from edk2-libc/StdLib/PosixLib/Gen/access.c:14:
edk2-libc/StdLib/Include/sys/EfiCdefs.h:336:11: error: redefining builtin macro [-Werror,-Wbuiltin-macro-redefined]
  336 |   #define __STDC_VERSION__    199409L
      |           ^
Building ... edk2-libc/StdLib/PosixLib/PosixLib.inf [X64]
1 error generated.
```

This is because Clang already has builtin `__STDC_VERSION__` but because of `x86_64-pc-windows-msvc` target then `#if defined(_MSC_VER) ` is true causing to enter in this path for MSVC++ defines.

This PR fixes this issue by removing `_MSC_VER`  definition.
This is alternative solution to tianocore/edk2#12239
Note that it's not practical to add this flag to individual `.inf` files because there are too many that need it so adding to whole `StdLib.dsc` is simpler.
