### PR TITLE
edk2-libc: Update GCC GitHub Actions to support Node.js 24

### DIFF
--- a/.github/workflows/build-python-uefi-gcc.yaml
+++ b/.github/workflows/build-python-uefi-gcc.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 
@@ -63,7 +63,7 @@ jobs:
         ls -R edk2/myUEFIPy
 
     - name: Upload build output as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.5.0
       with:
         name: myUEFIPy-build-gcc-output
         path: edk2/myUEFIPy/**/*


### PR DESCRIPTION
REF: https://github.com/tianocore/edk2-libc/issues/98

The GCC GitHub build action is failing due to deprecated Node.js 20 dependencies. Node.js 20 actions are deprecated and will be removed from GitHub Actions runners on September 16th, 2026.

Updated the following actions to versions that support Node.js 24:
- actions/checkout@v4 -> actions/checkout@v5
- actions/setup-python@v5 -> actions/setup-python@v6
- actions/upload-artifact@v4 -> actions/upload-artifact@v4.5.0

This ensures the build-python-uefi-gcc.yaml workflow continues to function properly with the new GitHub Actions runtime requirements.

Closes #98