### PR TITLE
Fix GCC toolchain settings in AppPkg CI

### DIFF
--- a/.github/workflows/build-app-uefi-gcc.yaml
+++ b/.github/workflows/build-app-uefi-gcc.yaml
@@ -10,9 +10,9 @@ on:
 
 env:
   BUILD_TYPE: RELEASE
-  COMPILER: GCC5
-  GCC5_AARCH64_PREFIX: aarch64-linux-gnu-
-  GCC5_LOONGARCH64_PREFIX: loongarch64-unknown-linux-gnu-
+  COMPILER: GCC
+  GCC_AARCH64_PREFIX: aarch64-linux-gnu-
+  GCC_LOONGARCH64_PREFIX: loongarch64-unknown-linux-gnu-
 
 jobs:
   build:
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Download and Install loongarch64 toolchain
-        if: matrix.arch == 'loongarch64'
+        if: matrix.arch == 'LOONGARCH64'
         run: |
           curl -L -O https://github.com/loongson/build-tools/releases/download/2024.11.01/x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz
           tar -xJf x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz


### PR DESCRIPTION
## Summary

The AppPkg GCC workflow still uses the deprecated `GCC5` toolchain tag and `GCC5_*` cross-prefix environment variables.

Current edk2 BaseTools has removed the legacy GCC5 toolchain definitions and uses the `GCC` toolchain tag with `GCC_*` prefix variables instead. As a result, the workflow fails before it can build with current edk2.

This PR updates the workflow to match current edk2 toolchain naming:

- Use `COMPILER: GCC` instead of `GCC5`
- Rename `GCC5_AARCH64_PREFIX` to `GCC_AARCH64_PREFIX`
- Rename `GCC5_LOONGARCH64_PREFIX` to `GCC_LOONGARCH64_PREFIX`
- Match the `LOONGARCH64` matrix value when installing the LoongArch64 toolchain

## Validation

Locally verified that current edk2 no longer defines `GCC5`, and that the X64 StdLib/AppPkg workflow build proceeds with the `GCC` toolchain.

Fixes #109
