### PR TITLE
StdLib: Remove unused Arm flt_rounds map

### DIFF
--- a/StdLib/LibC/Main/Arm/flt_rounds.c
+++ b/StdLib/LibC/Main/Arm/flt_rounds.c
@@ -39,13 +39,6 @@ __RCSID("$NetBSD: flt_rounds.c,v 1.3 2006/02/25 00:58:35 wiz Exp $");
 #include <sys/types.h>
 //#include <ieeefp.h>
 
-static const int map[] = {
-  1,  /* round to nearest */
-  2,  /* round to positive infinity */
-  3,  /* round to negative infinity */
-  0   /* round to zero */
-};
-
 /*
  * Return the current FP rounding mode
  *
@@ -55,8 +48,6 @@ static const int map[] = {
  *  2 - round to positive infinity
  *  3 - round to negative infinity
  *
- * ok all we need to do is get the current FP rounding mode
- * index our map table and return the appropriate value.
  *
  * HOWEVER:
  * The ARM FPA codes the rounding mode into the actual FP instructions


### PR DESCRIPTION
## Summary
- Remove the unused `map` table from `StdLib/LibC/Main/Arm/flt_rounds.c`.
- Remove the stale comment that still described indexing that table.
- Preserve the current behavior of returning round-to-nearest by default.

## Root Cause
The Arm `flt_rounds` implementation originally used the table to translate
`fpgetround()` values to `FLT_ROUNDS` values. That lookup was later replaced
by a TODO fallback that always returns the default round-to-nearest value,
but the table was left behind.

The table is therefore dead code. The issue is exposed by the AARCH64 GCC
build because warnings are treated as errors, so the unused static const
variable fails the build.

## Testing
- `git diff --check HEAD~1 HEAD`
- Lightweight syntax check for `StdLib/LibC/Main/Arm/flt_rounds.c`

Fixes https://github.com/tianocore/edk2-libc/issues/111
