### PR TITLE
AppPkg/Applications/Enquire: explicitly set -std=gnu89 for GCC

### DIFF
--- a/AppPkg/Applications/Enquire/Enquire.inf
+++ b/AppPkg/Applications/Enquire/Enquire.inf
@@ -50,5 +50,5 @@
 [BuildOptions]
      INTEL:*_*_*_CC_FLAGS = /Qdiag-disable:181,186
       MSFT:*_*_*_CC_FLAGS = /Od
-       GCC:*_*_*_CC_FLAGS = -O0 -Wno-unused-variable
+       GCC:*_*_*_CC_FLAGS = -O0 -Wno-unused-variable -std=gnu89
   CLANGPDB:*_*_*_CC_FLAGS = -Wno-unused-variable -Wno-builtin-macro-redefined -D__FILE__=__FILE_NAME__


### PR DESCRIPTION
Recent GCC defaults to a newer C standard, to which the ancient Enquire code does not conform.

Explicitly set -std=gnu89 for it.

This is tested to build on GCC 15.