### PR TITLE
StdLib/LibC: Fix LTO linking with Clang

### DIFF
--- a/StdLib/LibC/Main/errno.c
+++ b/StdLib/LibC/Main/errno.c
@@ -14,6 +14,12 @@
 int             errno     = 0;
 RETURN_STATUS   EFIerrno  = RETURN_SUCCESS;
 
+#if defined(__GNUC__) || defined(__clang__)
+#define GLOBAL_USED  __attribute__((used))
+#else
+#define GLOBAL_USED
+#endif
+
 // This is required to keep VC++ happy if you use floating-point
-int _fltused  = 1;
-int __sse2_available = 0;   ///< Used by ftol2_sse
+int  GLOBAL_USED  _fltused  = 1;
+int  GLOBAL_USED  __sse2_available = 0;   ///< Used by ftol2_sse


### PR DESCRIPTION
When using Clang on Linux and building with LTO then `_fltused` would be removed causing linking failure.

```
$ build -t CLANGPDB -b RELEASE -a X64 -p AppPkg/AppPkg.dsc -m AppPkg/Applications/ArithChk/ArithChk.inf
[...]
"llvm-lib"  /OUT:edk2/Build/AppPkg/RELEASE_CLANGPDB/X64/edk2-libc/AppPkg/Applications/ArithChk/ArithChk/OUTPUT/ArithChk.lib @edk2/Build/AppPkg/RELEASE_CLANGPDB/X64/edk2-libc/AppPkg/Applications/ArithChk/ArithChk/OUTPUT/object_files.lst
"lld-link" /OUT:edk2/Build/AppPkg/RELEASE_CLANGPDB/X64/edk2-libc/AppPkg/Applications/ArithChk/ArithChk/DEBUG/ArithChk.dll /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4254 /OPT:REF /OPT:ICF=10 /ALIGN:4096 /DRIVER /FILEALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:X64 /DLL /ENTRY:_ModuleEntryPoint /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /MERGE:.rdata=.data /MLLVM:-exception-model=wineh /lldmap  @edk2/Build/AppPkg/RELEASE_CLANGPDB/X64/edk2-libc/AppPkg/Applications/ArithChk/ArithChk/OUTPUT/static_library_files.lst
lld-link: error: undefined symbol: _fltused
>>> referenced by edk2/Build/AppPkg/RELEASE_CLANGPDB/X64/edk2-libc/AppPkg/Applications/ArithChk/ArithChk/DEBUG/ArithChk.dll.lto.obj
make: *** [GNUmakefile:405: edk2/Build/AppPkg/RELEASE_CLANGPDB/X64/edk2-libc/AppPkg/Applications/ArithChk/ArithChk/DEBUG/ArithChk.dll] Error 1
```

Here I fixed it in exactly same way as it's done in [edk2/CryptoPkg/Library/IntrinsicLib/MemoryIntrinsics.c:16-24](https://github.com/tianocore/edk2/blob/master/CryptoPkg/Library/IntrinsicLib/MemoryIntrinsics.c#L16-L24)