### PR TITLE
StdLib/EfiSocketLib: Implement TCP_NODELAY support for TCP4 and TCP6 sockets

### DIFF
--- a/StdLib/EfiSocketLib/Socket.h
+++ b/StdLib/EfiSocketLib/Socket.h
@@ -1,7 +1,7 @@
 /** @file
   Definitions for the Socket layer driver.
 
-  Copyright (c) 2011, Intel Corporation. All rights reserved.
+  Copyright (c) 2011 - 2026, Intel Corporation. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1005,6 +1005,7 @@ typedef struct _ESL_SOCKET {
   //
   BOOLEAN bIncludeHeader;       ///<  TRUE if including the IP header
   BOOLEAN bListenCalled;        ///<  TRUE if listen was successfully called
+  BOOLEAN bNoDelay;             ///<  TRUE if Nagle algorithm is disabled (TCP_NODELAY)
   BOOLEAN bOobInLine;           ///<  TRUE if out-of-band messages are to be received inline with normal data
   BOOLEAN bReUseAddr;           ///<  TRUE if using same address is allowed
 

--- a/StdLib/EfiSocketLib/Tcp4.c
+++ b/StdLib/EfiSocketLib/Tcp4.c
@@ -1,7 +1,7 @@
 /** @file
   Implement the TCP4 driver support for the socket layer.
 
-  Copyright (c) 2011 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2011 - 2026, Intel Corporation. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 
@@ -21,6 +21,7 @@
 **/
 
 #include "Socket.h"
+#include <netinet/tcp.h>
 
 
 /**
@@ -72,6 +73,30 @@ VOID EFIAPI
 EslTcp4ListenComplete (
   IN EFI_EVENT Event,
   IN VOID *contet
+  );
+
+
+/**
+  Set a TCP4 socket option.
+
+  This routine handles protocol-level option requests for TCPv4 sockets.
+  Currently only IPPROTO_TCP / TCP_NODELAY is supported.
+
+  @param [in] pSocket       Address of an ::ESL_SOCKET structure.
+  @param [in] OptionName    Name of the option to set.
+  @param [in] pOptionValue  Buffer containing the option value.
+  @param [in] OptionLength  Length of the buffer in bytes.
+
+  @retval EFI_SUCCESS           Option successfully set.
+  @retval EFI_INVALID_PARAMETER Unrecognised option or bad length.
+
+ **/
+EFI_STATUS
+EslTcp4OptionSet (
+  IN ESL_SOCKET * pSocket,
+  IN int OptionName,
+  IN CONST void * pOptionValue,
+  IN socklen_t OptionLength
   );
 
 
@@ -494,6 +519,7 @@ EslTcp4ConnectStart (
     pTcp4 = &pPort->Context.Tcp4;
     pTcp4->ConfigData.AccessPoint.ActiveFlag = TRUE;
     pTcp4->ConfigData.TimeToLive = 255;
+    pTcp4->ConfigData.ControlOption = pSocket->bNoDelay ? &pTcp4->Option : NULL;
     pTcp4Protocol = pPort->pProtocol.TCPv4;
     Status = pTcp4Protocol->Configure ( pTcp4Protocol,
                                         &pTcp4->ConfigData );
@@ -672,6 +698,7 @@ EslTcp4Listen (
         //  Configure the port
         //
         pTcp4Protocol = pPort->pProtocol.TCPv4;
+        pTcp4->ConfigData.ControlOption = pSocket->bNoDelay ? &pTcp4->Option : NULL;
         Status = pTcp4Protocol->Configure ( pTcp4Protocol,
                                             &pTcp4->ConfigData );
         if ( EFI_ERROR ( Status )) {
@@ -1320,6 +1347,7 @@ EslTcp4PortAllocate (
     pAccessPoint = &pPort->Context.Tcp4.ConfigData.AccessPoint;
     pAccessPoint->ActiveFlag = FALSE;
     pTcp4->ConfigData.TimeToLive = 255;
+    pTcp4->Option.EnableNagle = (BOOLEAN)( !pSocket->bNoDelay );
     break;
   }
 
@@ -2388,6 +2416,78 @@ EslTcp4VerifyLocalIpAddress (
 
 
 /**
+  Set a TCP4 socket option.
+
+  This routine handles protocol-level option requests for TCPv4 sockets.
+  Currently only IPPROTO_TCP / TCP_NODELAY is supported.
+
+  @param [in] pSocket       Address of an ::ESL_SOCKET structure.
+  @param [in] OptionName    Name of the option to set.
+  @param [in] pOptionValue  Buffer containing the option value.
+  @param [in] OptionLength  Length of the buffer in bytes.
+
+  @retval EFI_SUCCESS           Option successfully set.
+  @retval EFI_INVALID_PARAMETER Unrecognised option or bad length.
+
+ **/
+EFI_STATUS
+EslTcp4OptionSet (
+  IN ESL_SOCKET * pSocket,
+  IN int OptionName,
+  IN CONST void * pOptionValue,
+  IN socklen_t OptionLength
+  )
+{
+  ESL_PORT * pPort;
+  ESL_TCP4_CONTEXT * pTcp4;
+
+  DBG_ENTER ( );
+
+  //
+  //  Validate the option
+  //
+  if ( TCP_NODELAY != OptionName ) {
+    DEBUG (( DEBUG_OPTION,
+              "ERROR - EslTcp4OptionSet: unsupported option %d\r\n",
+              OptionName ));
+    pSocket->errno = ENOPROTOOPT;
+    DBG_EXIT_STATUS ( EFI_UNSUPPORTED );
+    return EFI_UNSUPPORTED;
+  }
+  if ( OptionLength < sizeof ( int )) {
+    DEBUG (( DEBUG_OPTION,
+              "ERROR - EslTcp4OptionSet: option %d length %d too small\r\n",
+              OptionName,
+              OptionLength ));
+    pSocket->errno = EINVAL;
+    DBG_EXIT_STATUS ( EFI_INVALID_PARAMETER );
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  //  Store the no-delay preference on the socket so port-allocate can pick
+  //  it up even when no ports exist yet.
+  //
+  pSocket->bNoDelay = (BOOLEAN)( 0 != *(CONST int *)pOptionValue );
+
+  //
+  //  Update any ports that are already allocated (e.g. after bind but before
+  //  connect / listen).
+  //
+  pPort = pSocket->pPortList;
+  while ( NULL != pPort ) {
+    pTcp4 = &pPort->Context.Tcp4;
+    pTcp4->Option.EnableNagle = (BOOLEAN)( !pSocket->bNoDelay );
+    pPort = pPort->pLinkSocket;
+  }
+
+  pSocket->errno = 0;
+  DBG_EXIT_STATUS ( EFI_SUCCESS );
+  return EFI_SUCCESS;
+}
+
+
+/**
   Interface between the socket layer and the network specific
   code that supports SOCK_STREAM and SOCK_SEQPACKET sockets
   over TCPv4.
@@ -2413,7 +2513,7 @@ CONST ESL_PROTOCOL_API cEslTcp4Api = {
   EslTcp4LocalAddressSet,
   EslTcp4Listen,
   NULL,   //  OptionGet
-  NULL,   //  OptionSet
+  EslTcp4OptionSet,   //  OptionSet
   EslTcp4PacketFree,
   EslTcp4PortAllocate,
   EslTcp4PortClose,

--- a/StdLib/EfiSocketLib/Tcp6.c
+++ b/StdLib/EfiSocketLib/Tcp6.c
@@ -1,7 +1,7 @@
 /** @file
   Implement the TCP6 driver support for the socket layer.
 
-  Copyright (c) 2011 - 2014, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2011 - 2026, Intel Corporation. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 
@@ -21,6 +21,7 @@
 **/
 
 #include "Socket.h"
+#include <netinet/tcp.h>
 
 
 /**
@@ -72,6 +73,30 @@ VOID EFIAPI
 EslTcp6ListenComplete (
   IN EFI_EVENT Event,
   IN VOID *pPort // IN ESL_PORT * pPort
+  );
+
+
+/**
+  Set a TCP6 socket option.
+
+  This routine handles protocol-level option requests for TCPv6 sockets.
+  Currently only IPPROTO_TCP / TCP_NODELAY is supported.
+
+  @param [in] pSocket       Address of an ::ESL_SOCKET structure.
+  @param [in] OptionName    Name of the option to set.
+  @param [in] pOptionValue  Buffer containing the option value.
+  @param [in] OptionLength  Length of the buffer in bytes.
+
+  @retval EFI_SUCCESS           Option successfully set.
+  @retval EFI_INVALID_PARAMETER Unrecognised option or bad length.
+
+ **/
+EFI_STATUS
+EslTcp6OptionSet (
+  IN ESL_SOCKET * pSocket,
+  IN int OptionName,
+  IN CONST void * pOptionValue,
+  IN socklen_t OptionLength
   );
 
 
@@ -513,6 +538,7 @@ EslTcp6ConnectStart (
     pTcp6->ConfigData.AccessPoint.ActiveFlag = TRUE;
     pTcp6->ConfigData.TrafficClass = 0;
     pTcp6->ConfigData.HopLimit = 255;
+    pTcp6->ConfigData.ControlOption = pSocket->bNoDelay ? &pTcp6->Option : NULL;
     pTcp6Protocol = pPort->pProtocol.TCPv6;
     Status = pTcp6Protocol->Configure ( pTcp6Protocol,
                                         &pTcp6->ConfigData );
@@ -703,6 +729,7 @@ EslTcp6Listen (
         //  Configure the port
         //
         pTcp6Protocol = pPort->pProtocol.TCPv6;
+        pTcp6->ConfigData.ControlOption = pSocket->bNoDelay ? &pTcp6->Option : NULL;
         Status = pTcp6Protocol->Configure ( pTcp6Protocol,
                                             &pTcp6->ConfigData );
         if ( EFI_ERROR ( Status )) {
@@ -1372,6 +1399,7 @@ EslTcp6PortAllocate (
     pAccessPoint->ActiveFlag = FALSE;
     pTcp6->ConfigData.TrafficClass = 0;
     pTcp6->ConfigData.HopLimit = 255;
+    pTcp6->Option.EnableNagle = (BOOLEAN)( !pSocket->bNoDelay );
     break;
   }
 
@@ -2552,6 +2580,78 @@ EslTcp6VerifyLocalIpAddress (
 
 
 /**
+  Set a TCP6 socket option.
+
+  This routine handles protocol-level option requests for TCPv6 sockets.
+  Currently only IPPROTO_TCP / TCP_NODELAY is supported.
+
+  @param [in] pSocket       Address of an ::ESL_SOCKET structure.
+  @param [in] OptionName    Name of the option to set.
+  @param [in] pOptionValue  Buffer containing the option value.
+  @param [in] OptionLength  Length of the buffer in bytes.
+
+  @retval EFI_SUCCESS           Option successfully set.
+  @retval EFI_INVALID_PARAMETER Unrecognised option or bad length.
+
+ **/
+EFI_STATUS
+EslTcp6OptionSet (
+  IN ESL_SOCKET * pSocket,
+  IN int OptionName,
+  IN CONST void * pOptionValue,
+  IN socklen_t OptionLength
+  )
+{
+  ESL_PORT * pPort;
+  ESL_TCP6_CONTEXT * pTcp6;
+
+  DBG_ENTER ( );
+
+  //
+  //  Validate the option
+  //
+  if ( TCP_NODELAY != OptionName ) {
+    DEBUG (( DEBUG_OPTION,
+              "ERROR - EslTcp6OptionSet: unsupported option %d\r\n",
+              OptionName ));
+    pSocket->errno = ENOPROTOOPT;
+    DBG_EXIT_STATUS ( EFI_UNSUPPORTED );
+    return EFI_UNSUPPORTED;
+  }
+  if ( OptionLength < sizeof ( int )) {
+    DEBUG (( DEBUG_OPTION,
+              "ERROR - EslTcp6OptionSet: option %d length %d too small\r\n",
+              OptionName,
+              OptionLength ));
+    pSocket->errno = EINVAL;
+    DBG_EXIT_STATUS ( EFI_INVALID_PARAMETER );
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  //  Store the no-delay preference on the socket so port-allocate can pick
+  //  it up even when no ports exist yet.
+  //
+  pSocket->bNoDelay = (BOOLEAN)( 0 != *(CONST int *)pOptionValue );
+
+  //
+  //  Update any ports that are already allocated (e.g. after bind but before
+  //  connect / listen).
+  //
+  pPort = pSocket->pPortList;
+  while ( NULL != pPort ) {
+    pTcp6 = &pPort->Context.Tcp6;
+    pTcp6->Option.EnableNagle = (BOOLEAN)( !pSocket->bNoDelay );
+    pPort = pPort->pLinkSocket;
+  }
+
+  pSocket->errno = 0;
+  DBG_EXIT_STATUS ( EFI_SUCCESS );
+  return EFI_SUCCESS;
+}
+
+
+/**
   Interface between the socket layer and the network specific
   code that supports SOCK_STREAM and SOCK_SEQPACKET sockets
   over TCPv6.
@@ -2577,7 +2677,7 @@ CONST ESL_PROTOCOL_API cEslTcp6Api = {
   EslTcp6LocalAddressSet,
   EslTcp6Listen,
   NULL,   //  OptionGet
-  NULL,   //  OptionSet
+  EslTcp6OptionSet,   //  OptionSet
   EslTcp6PacketFree,
   EslTcp6PortAllocate,
   EslTcp6PortClose,


### PR DESCRIPTION
When using network calls, users can't activate the TCP_NODELAY, to disable Nagle algorithm (mainly on closed/small networks). The pull request enables this option.

This PR fixes this issue: https://github.com/tianocore/edk2-libc/issues/117

Signed-off-by: Matan Perel <matan.perel@intel.com>